### PR TITLE
#126: Elastic**Service extension

### DIFF
--- a/studymanager-services/src/main/java/io/redlink/more/studymanager/service/ElasticDataService.java
+++ b/studymanager-services/src/main/java/io/redlink/more/studymanager/service/ElasticDataService.java
@@ -62,8 +62,12 @@ public class ElasticDataService {
         this.studyGroupService = studyGroupService;
     }
 
-    public DataViewData queryObservationViewData(ViewConfig viewConfig, long studyId, Integer studyGroupId, int observationId, Integer participantId, TimeRange timerange) throws IOException {
-        final List<Query> filters = getFilters(studyId, observationId, studyGroupId, participantId, timerange);
+    public DataViewData queryObservationViewData(ViewConfig viewConfig, Long studyId, Integer studyGroupId, Integer observationId, Integer participantId, TimeRange timerange) throws IOException {
+        return queryObservationViewData(viewConfig, studyId, studyGroupId, observationId, participantId, null, timerange);
+    }
+
+    public DataViewData queryObservationViewData(ViewConfig viewConfig, Long studyId, Integer studyGroupId, Integer observationId, Integer participantId, String dataType, TimeRange timerange) throws IOException {
+        final List<Query> filters = getFilters(studyId, observationId, studyGroupId, participantId, dataType, timerange);
 
         final SearchRequest.Builder builder = buildDataPreviewRequest(viewConfig, filters, studyId);
         final SearchRequest request = builder.build();

--- a/studymanager-services/src/main/java/io/redlink/more/studymanager/service/ElasticService.java
+++ b/studymanager-services/src/main/java/io/redlink/more/studymanager/service/ElasticService.java
@@ -109,15 +109,24 @@ public class ElasticService {
         return queries;
     }
 
-    static List<Query> getFilters(Long studyId, Integer observationId, Integer studyGroupId, Integer participantId, TimeRange timerange) {
+    static List<Query> getFilters(Long studyId, Integer observationId, Integer studyGroupId, Integer participantId, String dataType, TimeRange timerange) {
         List<Query> filters = new ArrayList<>();
+        if(studyId == null) {
+            throw new IllegalArgumentException("studyId cannot be null");
+        }
         filters.add(getStudyFilter(studyId));
-        filters.add(getObservationFilter(observationId));
+        if(observationId != null) {
+            filters.add(getObservationFilter(observationId));
+        }
 
         if (participantId != null) {
             filters.add(getParticipantFilter(participantId));
         } else if(studyGroupId != null) {
             filters.add(getStudyGroupFilter(studyGroupId));
+        }
+
+        if(dataType != null) {
+            filters.add(getDataTypeFilter(dataType));
         }
 
         if (timerange != null && timerange.getFromString() != null && timerange.getToString() != null) {
@@ -152,6 +161,13 @@ public class ElasticService {
                 term(t -> t.
                         field("participant_id.keyword").
                         value(getParticipantIdString(participantId))));
+    }
+
+    static Query getDataTypeFilter(String dataType) {
+        return Query.of(f -> f.
+                term(t -> t.
+                        field("data_type.keyword").
+                        value(dataType)));
     }
 
     static Query getTimeRangeFilter(TimeRange timerange) {


### PR DESCRIPTION
* adds support for filters based on the `data_type`
* makes the `observation_id` filter optional (if `null` is parsed as `observation_id`)