### PR TITLE
#249 #250 #251 multi observation groups for observations interventions

### DIFF
--- a/studymanager-services/src/main/java/io/redlink/more/studymanager/model/Intervention.java
+++ b/studymanager-services/src/main/java/io/redlink/more/studymanager/model/Intervention.java
@@ -11,6 +11,8 @@ package io.redlink.more.studymanager.model;
 import io.redlink.more.studymanager.model.scheduler.ScheduleEvent;
 
 import java.time.Instant;
+import java.util.HashSet;
+import java.util.Set;
 
 public class Intervention {
     private Long studyId;
@@ -21,7 +23,7 @@ public class Intervention {
     private ScheduleEvent schedule;
     private Instant created;
     private Instant modified;
-    private Integer observationGroupId;
+    private Set<Integer> observationGroupIds;
 
     public Long getStudyId() {
         return studyId;
@@ -68,15 +70,6 @@ public class Intervention {
         return this;
     }
 
-    public Integer getObservationGroupId() {
-        return observationGroupId;
-    }
-
-    public Intervention setObservationGroupId(Integer observationGroupId) {
-        this.observationGroupId = observationGroupId;
-        return this;
-    }
-
     public ScheduleEvent getSchedule() {
         return schedule;
     }
@@ -103,4 +96,14 @@ public class Intervention {
         this.modified = modified;
         return this;
     }
+
+    public Intervention setObservationGroupIds(Set<Integer> observationGroupIds) {
+        this.observationGroupIds = observationGroupIds == null ? new HashSet<>() : observationGroupIds;
+        return this;
+    }
+
+    public Set<Integer> getObservationGroupIds() {
+        return observationGroupIds;
+    }
+
 }

--- a/studymanager-services/src/main/java/io/redlink/more/studymanager/model/Observation.java
+++ b/studymanager-services/src/main/java/io/redlink/more/studymanager/model/Observation.java
@@ -12,6 +12,8 @@ import io.redlink.more.studymanager.core.properties.ObservationProperties;
 import io.redlink.more.studymanager.model.scheduler.ScheduleEvent;
 
 import java.time.Instant;
+import java.util.HashSet;
+import java.util.Set;
 
 public class Observation {
     private Long studyId;
@@ -27,7 +29,7 @@ public class Observation {
     private Instant modified;
     private Boolean hidden;
     private Boolean noSchedule = false;
-    private Integer observationGroupId;
+    private Set<Integer> observationGroupIds;
 
     public Long getStudyId() {
         return studyId;
@@ -92,15 +94,6 @@ public class Observation {
         return this;
     }
 
-    public Integer getObservationGroupId() {
-        return observationGroupId;
-    }
-
-    public Observation setObservationGroupId(Integer observationGroupId) {
-        this.observationGroupId = observationGroupId;
-        return this;
-    }
-
     public ObservationProperties getProperties() {
         return properties;
     }
@@ -152,4 +145,14 @@ public class Observation {
         this.noSchedule = noSchedule;
         return this;
     }
+
+    public Observation setObservationGroupIds(Set<Integer> observationGroupIds) {
+        this.observationGroupIds = observationGroupIds == null ? new HashSet<>() : observationGroupIds;
+        return this;
+    }
+
+    public Set<Integer> getObservationGroupIds() {
+        return observationGroupIds;
+    }
+
 }

--- a/studymanager-services/src/main/java/io/redlink/more/studymanager/repository/InterventionRepository.java
+++ b/studymanager-services/src/main/java/io/redlink/more/studymanager/repository/InterventionRepository.java
@@ -22,25 +22,54 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import static io.redlink.more.studymanager.repository.RepositoryUtils.getValidNullableIntegerValue;
 
 @Component
 public class InterventionRepository {
 
-    private static final String INSERT_INTERVENTION = "INSERT INTO interventions(study_id,intervention_id,title,purpose,study_group_id,schedule,observation_group_id) VALUES (:study_id,(SELECT COALESCE(MAX(intervention_id),0)+1 FROM interventions WHERE study_id = :study_id),:title,:purpose,:study_group_id,:schedule::jsonb,:observation_group_id) RETURNING *";
-    private static final String IMPORT_INTERVENTION = "INSERT INTO interventions(study_id,intervention_id,title,purpose,study_group_id,schedule,observation_group_id) VALUES (:study_id,:intervention_id,:title,:purpose,:study_group_id,:schedule::jsonb,:observation_group_id) RETURNING *";
-    private static final String GET_INTERVENTION_BY_IDS = "SELECT * FROM interventions WHERE study_id = ? AND intervention_id = ?";
-    private static final String LIST_INTERVENTIONS = "SELECT * FROM interventions WHERE study_id = ?";
-    private static final String LIST_INTERVENTIONS_FOR_GROUP = "SELECT * FROM interventions WHERE study_id = :study_id AND (study_group_id IS NULL OR study_group_id = :study_group_id) AND (observation_group_id IS NULL OR observation_group_id = ANY(:observation_group_ids::INT[]))";
+    private static final String INSERT_INTERVENTION = "INSERT INTO interventions(study_id,intervention_id,title,purpose,study_group_id,schedule) VALUES (:study_id,(SELECT COALESCE(MAX(intervention_id),0)+1 FROM interventions WHERE study_id = :study_id),:title,:purpose,:study_group_id,:schedule::jsonb)";
+    private static final String IMPORT_INTERVENTION = "INSERT INTO interventions(study_id,intervention_id,title,purpose,study_group_id,schedule) VALUES (:study_id,:intervention_id,:title,:purpose,:study_group_id,:schedule::jsonb)";
+    private static final String GET_INTERVENTION_BY_IDS = """
+        SELECT i.*, ARRAY_AGG(iog.observation_group_id) FILTER (WHERE iog.observation_group_id IS NOT NULL) AS observation_group_ids
+        FROM interventions i
+            LEFT JOIN intervention_observation_groups iog ON i.study_id = iog.study_id AND i.intervention_id = iog.intervention_id
+        WHERE i.study_id = ? AND i.intervention_id = ?
+        GROUP BY i.study_id, i.intervention_id""";
+    private static final String LIST_INTERVENTIONS = """
+        SELECT i.*, ARRAY_AGG(iog.observation_group_id) FILTER (WHERE iog.observation_group_id IS NOT NULL) AS observation_group_ids
+        FROM interventions i
+            LEFT JOIN intervention_observation_groups iog ON i.study_id = iog.study_id AND i.intervention_id = iog.intervention_id
+        WHERE i.study_id = ?
+        GROUP BY i.study_id, i.intervention_id""";
+    private static final String LIST_INTERVENTIONS_FOR_GROUP = """
+        SELECT i.*, ARRAY_AGG(iog.observation_group_id) FILTER (WHERE iog.observation_group_id IS NOT NULL) AS observation_group_ids
+        FROM interventions i
+            LEFT JOIN intervention_observation_groups iog ON i.study_id = iog.study_id AND i.intervention_id = iog.intervention_id
+        WHERE i.study_id = :study_id
+          AND (i.study_group_id IS NULL OR i.study_group_id = :study_group_id)
+          AND (NOT EXISTS (
+            SELECT 1 FROM intervention_observation_groups iog3
+            WHERE iog3.study_id = i.study_id
+              AND iog3.intervention_id = i.intervention_id
+            ) OR EXISTS (
+            SELECT 1 FROM intervention_observation_groups iog2
+            WHERE iog2.study_id = i.study_id
+              AND iog2.intervention_id = i.intervention_id
+              AND iog2.observation_group_id = ANY(:observation_group_ids)))
+        GROUP BY i.study_id, i.intervention_id""";
     private static final String DELETE_INTERVENTION_BY_IDS = "DELETE FROM interventions WHERE study_id = ? AND intervention_id = ?";
     private static final String DELETE_ALL = "DELETE FROM interventions";
-    private static final String UPDATE_INTERVENTION = "UPDATE interventions SET title=:title, study_group_id=:study_group_id, purpose=:purpose, schedule=:schedule::jsonb, observation_group_id=:observation_group_id WHERE study_id=:study_id AND intervention_id=:intervention_id";
+    private static final String UPDATE_INTERVENTION = "UPDATE interventions SET title=:title, study_group_id=:study_group_id, purpose=:purpose, schedule=:schedule::jsonb WHERE study_id=:study_id AND intervention_id=:intervention_id";
     private static final String CREATE_ACTION = "INSERT INTO actions(study_id,intervention_id,action_id,type,properties) VALUES (:study_id,:intervention_id,(SELECT COALESCE(MAX(action_id),0)+1 FROM actions WHERE study_id = :study_id AND intervention_id=:intervention_id),:type,:properties::jsonb) RETURNING *";
     private static final String IMPORT_ACTION = "INSERT INTO actions(study_id,intervention_id,action_id,type,properties) VALUES (:study_id,:intervention_id,:action_id,:type,:properties::jsonb) RETURNING *";
     private static final String GET_ACTION_BY_IDS = "SELECT * FROM actions WHERE study_id=? AND intervention_id=? AND action_id=?";
@@ -50,6 +79,18 @@ public class InterventionRepository {
     private static final String UPSERT_TRIGGER = "INSERT INTO triggers(study_id,intervention_id,type,properties) VALUES(:study_id,:intervention_id,:type,:properties::jsonb) ON CONFLICT ON CONSTRAINT triggers_pkey DO UPDATE SET type=:type, properties=:properties::jsonb, modified = now()";
     private static final String IMPORT_TRIGGER = "INSERT INTO triggers(study_id,intervention_id,type,properties) VALUES(:study_id,:intervention_id,:type,:properties::jsonb) RETURNING *";
     private static final String GET_TRIGGER_BY_IDS = "SELECT * FROM triggers WHERE study_id = ? AND intervention_id = ?";
+
+    /*
+     * SQL Statements for managing participant_observation_groups mapping for participants
+     */
+    private static final String DELETE_INVERVENTION_OBSERVATION_GROUP_IDS =
+            "DELETE FROM intervention_observation_groups " +
+                    "WHERE study_id = :study_id AND intervention_id = :intervention_id;";
+
+    private static final String SET_INVERVENTION_OBSERVATION_GROUP_IDS =
+            "INSERT INTO intervention_observation_groups (study_id, intervention_id, observation_group_id) " +
+                    "SELECT :study_id, :intervention_id, unnest(:observation_group_ids::int[]);";
+
     private final JdbcTemplate template;
     private final NamedParameterJdbcTemplate namedTemplate;
 
@@ -59,29 +100,36 @@ public class InterventionRepository {
     }
 
     public Intervention insert(Intervention intervention) {
+        final KeyHolder keyHolder = new GeneratedKeyHolder();
         try {
-            return namedTemplate.queryForObject(INSERT_INTERVENTION, interventionToParams(intervention), getInterventionRowMapper());
+            namedTemplate.update(INSERT_INTERVENTION, interventionToParams(intervention), keyHolder, new String[]{"intervention_id"});
         } catch (DataIntegrityViolationException e) {
-            throw new BadRequestException("Unable to insert Invervention because it refers an not existing group (Study group " + intervention.getStudyGroupId() + " and/or Observation group " + intervention.getObservationGroupId() + " does not exist on study " + intervention.getStudyId());
+            throw new BadRequestException(
+                    "Unable to insert Invervention because it refers an study group " + intervention.getStudyGroupId() +
+                    "that does not exist for study " + intervention.getStudyId());
         }
+        Integer interventionId = keyHolder.getKey().intValue();
+        setInverventionObservationGroupIds(intervention.getStudyId(), interventionId, intervention.getObservationGroupIds());
+        return getByIds(intervention.getStudyId(), interventionId);
     }
 
     public Intervention importIntervention(Long studyId, Intervention intervention) {
+        final KeyHolder keyHolder = new GeneratedKeyHolder();
         try {
-            return namedTemplate.queryForObject(IMPORT_INTERVENTION,
+            namedTemplate.update(IMPORT_INTERVENTION,
                     interventionToParams(intervention)
                             .addValue("study_id", studyId)
                             .addValue("intervention_id", intervention.getInterventionId()),
-                    getInterventionRowMapper());
+                    keyHolder,
+                    new String[]{"intervention_id"});
         } catch (DataIntegrityViolationException e) {
             throw new BadRequestException(
-                    "Error during import of intervention " +
-                            intervention.getInterventionId() +
-                            "for study " +
-                            intervention.getStudyId() +
-                            "(" + e.getClass().getSimpleName() + ": " + e.getMessage() + ")"
-            );
+                    "Error during import of intervention " + intervention.getInterventionId() + "for study " +
+                    intervention.getStudyId() + "(" + e.getClass().getSimpleName() + ": " + e.getMessage() + ")");
         }
+        Integer interventionId = keyHolder.getKey().intValue();
+        setInverventionObservationGroupIds(intervention.getStudyId(), interventionId, intervention.getObservationGroupIds());
+        return getByIds(intervention.getStudyId(), interventionId);
     }
 
     public List<Intervention> listInterventions(Long studyId) {
@@ -108,8 +156,10 @@ public class InterventionRepository {
         template.update(DELETE_INTERVENTION_BY_IDS, studyId, interventionId);
     }
 
+    @Transactional
     public Intervention updateIntervention(Intervention intervention) {
         namedTemplate.update(UPDATE_INTERVENTION, interventionToParams(intervention).addValue("intervention_id", intervention.getInterventionId()));
+        setInverventionObservationGroupIds(intervention.getStudyId(), intervention.getInterventionId(), intervention.getObservationGroupIds());
         return getByIds(intervention.getStudyId(), intervention.getInterventionId());
     }
 
@@ -191,20 +241,29 @@ public class InterventionRepository {
         template.update(DELETE_ALL);
     }
 
-    private static MapSqlParameterSource interventionToParams(Intervention intervention) {
+    private static MapSqlParameterSource toParams(Long studyId) {
         return new MapSqlParameterSource()
-                .addValue("study_id", intervention.getStudyId())
+                .addValue("study_id", studyId)
+                ;
+    }
+
+    private static MapSqlParameterSource toParams(Long studyId, Integer interventionId) {
+        return toParams(studyId)
+                .addValue("intervention_id", interventionId);
+    }
+
+
+
+    private static MapSqlParameterSource interventionToParams(Intervention intervention) {
+        return toParams(intervention.getStudyId())
                 .addValue("title", intervention.getTitle())
                 .addValue("purpose", intervention.getPurpose())
                 .addValue("study_group_id", intervention.getStudyGroupId())
-                .addValue("schedule", MapperUtils.writeValueAsString(intervention.getSchedule()))
-                .addValue("observation_group_id", intervention.getObservationGroupId());
+                .addValue("schedule", MapperUtils.writeValueAsString(intervention.getSchedule()));
     }
 
     private static MapSqlParameterSource triggerToParams(Long studyId, Integer interventionId, Trigger trigger) {
-        return new MapSqlParameterSource()
-                .addValue("study_id", studyId)
-                .addValue("intervention_id", interventionId)
+        return toParams(studyId, interventionId)
                 .addValue("type", trigger.getType())
                 .addValue("properties", MapperUtils.writeValueAsString(trigger.getProperties()));
     }
@@ -244,6 +303,16 @@ public class InterventionRepository {
                 .setStudyGroupId(getValidNullableIntegerValue(rs, "study_group_id"))
                 .setCreated(RepositoryUtils.readInstant(rs,"created"))
                 .setModified(RepositoryUtils.readInstant(rs,"modified"))
-                .setObservationGroupId(getValidNullableIntegerValue(rs, "observation_group_id"));
+                .setObservationGroupIds(RepositoryUtils.readSet(rs, "observation_group_ids", Integer.class));
         }
+
+    private void setInverventionObservationGroupIds(Long studyId, Integer interventionId, Set<Integer> observationGroupIds) {
+        final var params = toParams(studyId, interventionId);
+        namedTemplate.update(DELETE_INVERVENTION_OBSERVATION_GROUP_IDS, params);
+        if (observationGroupIds != null && !observationGroupIds.isEmpty()) {
+            params.addValue("observation_group_ids", observationGroupIds.toArray(new Integer[0]));
+            namedTemplate.update(SET_INVERVENTION_OBSERVATION_GROUP_IDS, params);
+        }
+    }
+
 }

--- a/studymanager-services/src/main/java/io/redlink/more/studymanager/repository/ObservationRepository.java
+++ b/studymanager-services/src/main/java/io/redlink/more/studymanager/repository/ObservationRepository.java
@@ -23,14 +23,12 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 import static io.redlink.more.studymanager.repository.RepositoryUtils.getValidNullableIntegerValue;
 
@@ -39,19 +37,56 @@ public class ObservationRepository {
 
     private final static Logger LOG = LoggerFactory.getLogger(ObservationRepository.class);
 
-    private static final String INSERT_NEW_OBSERVATION = "INSERT INTO observations(study_id,observation_id,title,purpose,participant_info,type,study_group_id,properties,schedule,hidden,no_schedule,observation_group_id) VALUES (:study_id,(SELECT COALESCE(MAX(observation_id),0)+1 FROM observations WHERE study_id = :study_id),:title,:purpose,:participant_info,:type,:study_group_id,:properties::jsonb,:schedule::jsonb,:hidden,:no_schedule,:observation_group_id) RETURNING *";
-    private static final String IMPORT_OBSERVATION = "INSERT INTO observations(study_id,observation_id,title,purpose,participant_info,type,study_group_id,properties,schedule,hidden,no_schedule,observation_group_id) VALUES (:study_id,:observation_id,:title,:purpose,:participant_info,:type,:study_group_id,:properties::jsonb,:schedule::jsonb,:hidden,:no_schedule,:observation_group_id) RETURNING *";
-    private static final String GET_OBSERVATION_BY_IDS = "SELECT * FROM observations WHERE study_id = ? AND observation_id = ?";
+    private static final String INSERT_NEW_OBSERVATION = "INSERT INTO observations(study_id,observation_id,title,purpose,participant_info,type,study_group_id,properties,schedule,hidden,no_schedule) VALUES (:study_id,(SELECT COALESCE(MAX(observation_id),0)+1 FROM observations WHERE study_id = :study_id),:title,:purpose,:participant_info,:type,:study_group_id,:properties::jsonb,:schedule::jsonb,:hidden,:no_schedule)";
+    private static final String IMPORT_OBSERVATION = "INSERT INTO observations(study_id,observation_id,title,purpose,participant_info,type,study_group_id,properties,schedule,hidden,no_schedule) VALUES (:study_id,:observation_id,:title,:purpose,:participant_info,:type,:study_group_id,:properties::jsonb,:schedule::jsonb,:hidden,:no_schedule)";
+    private static final String GET_OBSERVATION_BY_IDS = """
+        SELECT o.*, ARRAY_AGG(oog.observation_group_id) FILTER (WHERE oog.observation_group_id IS NOT NULL) AS observation_group_ids
+        FROM observations o
+            LEFT JOIN observation_observation_groups oog ON o.study_id = oog.study_id AND o.observation_id = oog.observation_id
+        WHERE o.study_id = ? AND o.observation_id = ?
+        GROUP BY o.study_id, o.observation_id""";
     private static final String DELETE_BY_IDS = "DELETE FROM observations WHERE study_id = ? AND observation_id = ?";
-    private static final String LIST_OBSERVATIONS = "SELECT * FROM observations WHERE study_id = :study_id";
-    private static final String LIST_OBSERVATIONS_FOR_GROUP = "SELECT * FROM observations WHERE study_id = :study_id AND (study_group_id IS NULL OR study_group_id = :study_group_id) AND (observation_group_id IS NULL OR observation_group_id = ANY(:observation_group_ids::INT[]))";
-    private static final String UPDATE_OBSERVATION = "UPDATE observations SET title=:title, purpose=:purpose, participant_info=:participant_info, study_group_id=:study_group_id, properties=:properties::jsonb, schedule=:schedule::jsonb, observation_group_id=:observation_group_id, modified=now(), hidden=:hidden, no_schedule=:no_schedule WHERE study_id=:study_id AND observation_id=:observation_id";
+    private static final String LIST_OBSERVATIONS = """
+        SELECT o.*, ARRAY_AGG(oog.observation_group_id) FILTER (WHERE oog.observation_group_id IS NOT NULL) AS observation_group_ids
+        FROM observations o
+            LEFT JOIN observation_observation_groups oog ON o.study_id = oog.study_id AND o.observation_id = oog.observation_id
+        WHERE o.study_id = :study_id
+        GROUP BY o.study_id, o.observation_id""";
+    private static final String LIST_OBSERVATIONS_FOR_GROUP = """
+        SELECT o.*, ARRAY_AGG(oog.observation_group_id) FILTER (WHERE oog.observation_group_id IS NOT NULL) AS observation_group_ids
+        FROM observations o
+            LEFT JOIN observation_observation_groups oog ON o.study_id = oog.study_id AND o.observation_id = oog.observation_id
+        WHERE o.study_id = :study_id
+          AND (o.study_group_id IS NULL OR o.study_group_id = :study_group_id)
+          AND (NOT EXISTS (
+            SELECT 1 FROM observation_observation_groups oog3\s
+            WHERE oog3.study_id = o.study_id
+              AND oog3.observation_id = o.observation_id
+            ) OR EXISTS (
+              SELECT 1 FROM observation_observation_groups oog2
+              WHERE oog2.study_id = o.study_id
+                AND oog2.observation_id = o.observation_id
+                AND oog2.observation_group_id = ANY(:observation_group_ids)))
+        GROUP BY o.study_id, o.observation_id""";
+    private static final String UPDATE_OBSERVATION = "UPDATE observations SET title=:title, purpose=:purpose, participant_info=:participant_info, study_group_id=:study_group_id, properties=:properties::jsonb, schedule=:schedule::jsonb, modified=now(), hidden=:hidden, no_schedule=:no_schedule WHERE study_id=:study_id AND observation_id=:observation_id";
     private static final String DELETE_ALL = "DELETE FROM observations";
     private static final String SET_OBSERVATION_PROPERTIES_FOR_PARTICIPANT = "INSERT INTO participant_observation_properties(study_id,participant_id,observation_id,properties) VALUES (:study_id,:participant_id,:observation_id,:properties::jsonb) ON CONFLICT (study_id, participant_id, observation_id) DO UPDATE SET properties = EXCLUDED.properties";
     private static final String GET_OBSERVATION_PROPERTIES_FOR_PARTICIPANT = "SELECT properties FROM participant_observation_properties WHERE  study_id = ? AND participant_id = ? AND observation_id = ?";
     private static final String GET_ALL_OBSERVATION_PROPERTIES_FOR_PARTICIPANT = "SELECT * FROM participant_observation_properties WHERE  study_id = ?";
     private static final String DELETE_OBSERVATION_PROPERTIES_FOR_PARTICIPANT = "DELETE FROM participant_observation_properties WHERE study_id = ? AND participant_id = ? AND observation_id = ?";
     private static final String REMOVE_PARTICIPANT_PROPERTY_KEY = "UPDATE participant_observation_properties SET properties = properties - :key WHERE study_id = :study_id AND observation_id = :observation_id";
+
+    /*
+     * SQL Statements for managing participant_observation_groups mapping for participants
+     */
+    private static final String DELETE_OBSERVATION_OBSERVATION_GROUP_IDS =
+            "DELETE FROM observation_observation_groups " +
+                    "WHERE study_id = :study_id AND observation_id = :observation_id;";
+
+    private static final String SET_OBSERVATION_OBSERVATION_GROUP_IDS =
+            "INSERT INTO observation_observation_groups (study_id, observation_id, observation_group_id) " +
+                    "SELECT :study_id, :observation_id, unnest(:observation_group_ids::int[]);";
+
 
     private final JdbcTemplate template;
     private final NamedParameterJdbcTemplate namedTemplate;
@@ -61,20 +96,16 @@ public class ObservationRepository {
         this.namedTemplate = new NamedParameterJdbcTemplate(template);
     }
 
+    @Transactional
     public Observation insert(Observation observation) {
+        final KeyHolder keyHolder = new GeneratedKeyHolder();
         try {
-            return namedTemplate.queryForObject(INSERT_NEW_OBSERVATION, toParams(observation), getObservationRowMapper());
+            namedTemplate.update(INSERT_NEW_OBSERVATION, toParams(observation), keyHolder, new String[]{"observation_id"});
         } catch (DataIntegrityViolationException e) {
             String message;
-            if (observation.getStudyGroupId() != null && observation.getObservationGroupId() != null) {
-                message = String.format("Study group %s and/or observation group %s do not exist on study %s",
-                        observation.getStudyGroupId(), observation.getObservationGroupId(), observation.getStudyId());
-            } else if (observation.getStudyGroupId() != null) {
+            if (observation.getStudyGroupId() != null) {
                 message = String.format("Study group %s does not exist on study %s",
                         observation.getStudyGroupId(), observation.getStudyId());
-            } else if (observation.getObservationGroupId() != null) {
-                message = String.format("Observation group %s does not exist on study %s",
-                        observation.getObservationGroupId(), observation.getStudyId());
             } else {
                 message = String.format("Encountered %s while inserting observation", e.getClass().getSimpleName());
                 LOG.warn("Unable to insert {}", observation, e);
@@ -84,17 +115,22 @@ public class ObservationRepository {
             LOG.warn("Unable to insert {}", observation, e);
             throw new BadRequestException("Unable to insert observation (" + e.getClass().getSimpleName() + ": " + e.getMessage() + ")");
         }
+        Integer observationId = keyHolder.getKey().intValue();
+        setObservationObservationGroupIds(observation.getStudyId(), observationId, observation.getObservationGroupIds());
+        return getById(observation.getStudyId(), observationId);
     }
 
+    @Transactional
     public Observation doImport(Long studyId, Observation observation) {
+        final KeyHolder keyHolder = new GeneratedKeyHolder();
         try {
-            return namedTemplate.queryForObject(
+            namedTemplate.update(
                     IMPORT_OBSERVATION,
                     toParams(observation)
-                            .addValue("study_id", studyId)
-                            .addValue("observation_id", observation.getObservationId()),
-                    getObservationRowMapper()
-            );
+                        .addValue("study_id", studyId)
+                        .addValue("observation_id", observation.getObservationId()),
+                    keyHolder,
+                    new String[]{"observation_id"});
         } catch (DataIntegrityViolationException | JsonProcessingException e) {
             throw new BadRequestException(
                     "Error during import of observation " +
@@ -103,6 +139,9 @@ public class ObservationRepository {
                             observation.getStudyId()
             );
         }
+        Integer observationId = keyHolder.getKey().intValue();
+        setObservationObservationGroupIds(observation.getStudyId(), observationId, observation.getObservationGroupIds());
+        return getById(observation.getStudyId(), observationId);
     }
 
     public Observation getById(Long studyId, Integer observationId) {
@@ -154,10 +193,12 @@ public class ObservationRepository {
         );
     }
 
+    @Transactional
     public Observation updateObservation(Observation observation) {
         try {
             namedTemplate.update(UPDATE_OBSERVATION,
                     toParams(observation).addValue("observation_id", observation.getObservationId()));
+            setObservationObservationGroupIds(observation.getStudyId(), observation.getObservationId(), observation.getObservationGroupIds());
             return getById(observation.getStudyId(), observation.getObservationId());
         } catch (JsonProcessingException e) {
             return null;
@@ -242,9 +283,19 @@ public class ObservationRepository {
         template.update(DELETE_OBSERVATION_PROPERTIES_FOR_PARTICIPANT, studyId, participantId, observationId);
     }
 
-    private static MapSqlParameterSource toParams(Observation observation) throws JsonProcessingException {
+    private static MapSqlParameterSource toParams(Long studyId) {
         return new MapSqlParameterSource()
-                .addValue("study_id", observation.getStudyId())
+                .addValue("study_id", studyId)
+                ;
+    }
+
+    private static MapSqlParameterSource toParams(Long studyId, Integer observationId) {
+        return toParams(studyId)
+                .addValue("observation_id", observationId);
+    }
+
+    private static MapSqlParameterSource toParams(Observation observation) throws JsonProcessingException {
+        return toParams(observation.getStudyId())
                 .addValue("title", observation.getTitle())
                 .addValue("purpose", observation.getPurpose())
                 .addValue("participant_info", observation.getParticipantInfo())
@@ -253,8 +304,7 @@ public class ObservationRepository {
                 .addValue("properties", MapperUtils.writeValueAsString(observation.getProperties()))
                 .addValue("schedule", MapperUtils.writeValueAsString(observation.getSchedule()))
                 .addValue("hidden", observation.getHidden())
-                .addValue("no_schedule", observation.getNoSchedule())
-                .addValue("observation_group_id", observation.getObservationGroupId());
+                .addValue("no_schedule", observation.getNoSchedule());
     }
 
     private static RowMapper<ObservationProperties> getParticipantObservationPropertiesRowMapper() {
@@ -276,6 +326,17 @@ public class ObservationRepository {
                 .setModified(RepositoryUtils.readInstant(rs, "modified"))
                 .setHidden(rs.getBoolean("hidden"))
                 .setNoSchedule(rs.getBoolean("no_schedule"))
-                .setObservationGroupId(RepositoryUtils.getValidNullableIntegerValue(rs, "observation_group_id"));
+                .setObservationGroupIds(RepositoryUtils.readSet(rs, "observation_group_ids", Integer.class));
     }
+
+    private void setObservationObservationGroupIds(Long studyId, Integer observationId, Set<Integer> observationGroupIds) {
+        final var params = toParams(studyId, observationId);
+        namedTemplate.update(DELETE_OBSERVATION_OBSERVATION_GROUP_IDS, params);
+        if (observationGroupIds != null && !observationGroupIds.isEmpty()) {
+            params.addValue("observation_group_ids", observationGroupIds.toArray(new Integer[0]));
+            namedTemplate.update(SET_OBSERVATION_OBSERVATION_GROUP_IDS, params);
+        }
+    }
+
+
 }

--- a/studymanager-services/src/main/resources/db/migration/V1_19_1__observation_groups_update.sql
+++ b/studymanager-services/src/main/resources/db/migration/V1_19_1__observation_groups_update.sql
@@ -1,0 +1,38 @@
+-- Observation Group Update
+--
+-- 1. Extension for multiple assignments of ObervationGroups to Observation
+-- 2. Extension for multiple assignments of ObervationGroups to Intervention
+
+-- Allow for multiple assignment of observations to observation_groups
+DROP INDEX observations_observation_group_id;
+
+ALTER TABLE observations
+    DROP COLUMN observation_group_id;
+
+CREATE TABLE observation_observation_groups (
+    study_id BIGINT NOT NULL,
+    observation_id INT NOT NULL,
+    observation_group_id INT NOT NULL,
+
+    PRIMARY KEY (study_id, observation_id, observation_group_id),
+    FOREIGN KEY (study_id) REFERENCES studies(study_id) ON DELETE CASCADE,
+    FOREIGN KEY (study_id, observation_group_id) REFERENCES observation_groups(study_id, observation_group_id) ON DELETE CASCADE,
+    FOREIGN KEY (study_id, observation_id) REFERENCES observations(study_id, observation_id) ON DELETE CASCADE
+);
+
+-- Allow for multiple assignment of interventions to observation_groups
+DROP INDEX interventions_observation_group_id;
+
+ALTER TABLE interventions
+    DROP COLUMN observation_group_id;
+
+CREATE TABLE intervention_observation_groups (
+    study_id BIGINT NOT NULL,
+    intervention_id INT NOT NULL,
+    observation_group_id INT NOT NULL,
+
+    PRIMARY KEY (study_id, intervention_id, observation_group_id),
+    FOREIGN KEY (study_id) REFERENCES studies(study_id) ON DELETE CASCADE,
+    FOREIGN KEY (study_id, observation_group_id) REFERENCES observation_groups(study_id, observation_group_id) ON DELETE CASCADE,
+    FOREIGN KEY (study_id, intervention_id) REFERENCES interventions(study_id, intervention_id) ON DELETE CASCADE
+);

--- a/studymanager-services/src/test/java/io/redlink/more/studymanager/repository/InterventionRepositoryTest.java
+++ b/studymanager-services/src/test/java/io/redlink/more/studymanager/repository/InterventionRepositoryTest.java
@@ -30,6 +30,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
@@ -83,7 +84,7 @@ class InterventionRepositoryTest {
                         .setDateStart(startTime)
                         .setDateEnd(endTime)
                         .setRRule(new RecurrenceRule().setFreq("DAILY").setCount(7)))
-                .setObservationGroupId(observationGroupId1);
+                .setObservationGroupIds(Set.of(observationGroupId1));
 
         //insert
         Intervention interventionResponse = interventionRepository.insert(intervention);
@@ -93,48 +94,58 @@ class InterventionRepositoryTest {
         assertThat(((Event)interventionResponse.getSchedule()).getDateStart()).isEqualTo(startTime);
         assertThat(MapperUtils.writeValueAsString(interventionResponse.getSchedule()))
                 .isEqualTo(MapperUtils.writeValueAsString(intervention.getSchedule()));
-        assertThat(interventionResponse.getObservationGroupId()).isEqualTo(observationGroupId1);
+        assertThat(interventionResponse.getObservationGroupIds()).containsExactlyInAnyOrder(observationGroupId1);
 
         //update
         interventionResponse = interventionRepository.updateIntervention(interventionResponse
                 .setTitle("some new title")
-                .setObservationGroupId(null));
+                .setObservationGroupIds(null));
 
         assertThat(interventionResponse.getTitle()).isEqualTo("some new title");
-        assertThat(interventionResponse.getObservationGroupId()).isNull();
+        assertThat(interventionResponse.getObservationGroupIds()).isEmpty();
 
         Intervention intervention2 = interventionRepository.insert(new Intervention()
                 .setStudyId(studyId)
                 .setTitle("Intervention 2")
                 .setSchedule(new Event().setDateEnd(Instant.now()).setDateEnd(Instant.now().plusSeconds(60)))
                 .setStudyGroupId(null)
-                .setObservationGroupId(null));
+                .setObservationGroupIds(Collections.emptySet()));
         Intervention intervention3a = interventionRepository.insert(new Intervention()
                 .setStudyId(studyId)
                 .setTitle("Intervaion 3a")
                 .setSchedule(new Event().setDateEnd(Instant.now()).setDateEnd(Instant.now().plusSeconds(60)))
                 .setStudyGroupId(null)
-                .setObservationGroupId(observationGroupId1));
+                .setObservationGroupIds(Set.of(observationGroupId1)));
         Intervention intervention3b = interventionRepository.insert(new Intervention()
                 .setStudyId(studyId)
                 .setTitle("Intervaion 3b")
                 .setSchedule(new Event().setDateEnd(Instant.now()).setDateEnd(Instant.now().plusSeconds(60)))
                 .setStudyGroupId(null)
-                .setObservationGroupId(observationGroupId2));
+                .setObservationGroupIds(Set.of(observationGroupId2)));
+        Intervention intervention3c = interventionRepository.insert(new Intervention()
+                .setStudyId(studyId)
+                .setTitle("Intervaion 3c")
+                .setSchedule(new Event().setDateEnd(Instant.now()).setDateEnd(Instant.now().plusSeconds(60)))
+                .setStudyGroupId(null)
+                .setObservationGroupIds(Set.of(observationGroupId1, observationGroupId2)));
         Intervention intervention4a = interventionRepository.insert(new Intervention()
                 .setStudyId(studyId)
                 .setTitle("Intervaion 4a")
                 .setSchedule(new Event().setDateEnd(Instant.now()).setDateEnd(Instant.now().plusSeconds(60)))
                 .setStudyGroupId(studyGroupId)
-                .setObservationGroupId(observationGroupId1));
+                .setObservationGroupIds(Set.of(observationGroupId1)));
         Intervention intervention4b = interventionRepository.insert(new Intervention()
                 .setStudyId(studyId)
                 .setTitle("Intervaion 4b")
                 .setSchedule(new Event().setDateEnd(Instant.now()).setDateEnd(Instant.now().plusSeconds(60)))
                 .setStudyGroupId(studyGroupId)
-                .setObservationGroupId(observationGroupId2));
+                .setObservationGroupIds(Set.of(observationGroupId2)));
 
-        assertThat(interventionRepository.listInterventions(studyId).size()).isEqualTo(6);
+        assertThat(interventionRepository.listInterventions(studyId).size()).isEqualTo(7);
+
+        //assert that intervation 3c has both expencted observation group ids
+        assertThat(interventionRepository.getByIds(studyId, intervention3c.getInterventionId()).getObservationGroupIds())
+                .containsExactlyInAnyOrder(observationGroupId1, observationGroupId2);
 
         //list interventions with no groups
         assertThat(interventionRepository.listInterventionsForGroup(studyId,null, Set.of()))
@@ -147,24 +158,24 @@ class InterventionRepositoryTest {
         //list interventions in observation group 1 with no studyGroup (or no studyGroup)
         assertThat(interventionRepository.listInterventionsForGroup(studyId,null, Set.of(observationGroupId1)))
                 .extracting(Intervention::getInterventionId)
-                .containsExactly(intervention2.getInterventionId(), intervention3a.getInterventionId());
+                .containsExactly(intervention2.getInterventionId(), intervention3a.getInterventionId(), intervention3c.getInterventionId());
         //same for none existing group
         assertThat(interventionRepository.listInterventionsForGroup(studyId,-1, Set.of(observationGroupId1)))
                 .extracting(Intervention::getInterventionId)
-                .containsExactly(intervention2.getInterventionId(), intervention3a.getInterventionId());
+                .containsExactly(intervention2.getInterventionId(), intervention3a.getInterventionId(), intervention3c.getInterventionId());
         //list interventions in study group 1 and observation group 1 with no studyGroup (or no studyGroup)
         assertThat(interventionRepository.listInterventionsForGroup(studyId, studyGroupId, Set.of(observationGroupId1)))
                 .extracting(Intervention::getInterventionId)
                 .containsExactly(
                         interventionResponse.getInterventionId(), intervention2.getInterventionId(),
-                        intervention3a.getInterventionId(), intervention4a.getInterventionId());
+                        intervention3a.getInterventionId(), intervention3c.getInterventionId(), intervention4a.getInterventionId());
 
         //list interventions in study group 1 and observation group 1 or observation group 2with no studyGroup (or no studyGroup)
         assertThat(interventionRepository.listInterventionsForGroup(studyId, studyGroupId, Set.of(observationGroupId1, observationGroupId2)))
                 .extracting(Intervention::getInterventionId)
                 .containsExactly(
                         interventionResponse.getInterventionId(), intervention2.getInterventionId(),
-                        intervention3a.getInterventionId(), intervention3b.getInterventionId(),
+                        intervention3a.getInterventionId(), intervention3b.getInterventionId(), intervention3c.getInterventionId(),
                         intervention4a.getInterventionId(), intervention4b.getInterventionId());
 
         interventionRepository.deleteByIds(interventionResponse.getStudyId(), interventionResponse.getInterventionId());
@@ -172,14 +183,14 @@ class InterventionRepositoryTest {
         interventionResponse = interventionRepository.getByIds(intervention2.getStudyId(), intervention2.getInterventionId());
 
         assertThat(interventionResponse.getInterventionId()).isEqualTo(intervention2.getInterventionId());
-        assertThat(interventionRepository.listInterventions(studyId).size()).isEqualTo(5);
+        assertThat(interventionRepository.listInterventions(studyId).size()).isEqualTo(6);
 
         //assert delete Observation Group sets property of Observation to null
         observationGroupRepository.deleteById(studyId, observationGroupId1);
-        assertThat((interventionRepository.getByIds(studyId, intervention3a.getInterventionId()).getObservationGroupId()))
-                .isNull();
-        assertThat((interventionRepository.getByIds(studyId, intervention4a.getInterventionId()).getObservationGroupId()))
-                .isNull();
+        assertThat((interventionRepository.getByIds(studyId, intervention3a.getInterventionId()).getObservationGroupIds()))
+                .isEmpty();;
+        assertThat((interventionRepository.getByIds(studyId, intervention4a.getInterventionId()).getObservationGroupIds()))
+                .isEmpty();
 
 
     }

--- a/studymanager-services/src/test/java/io/redlink/more/studymanager/repository/ObservationRepositoryTest.java
+++ b/studymanager-services/src/test/java/io/redlink/more/studymanager/repository/ObservationRepositoryTest.java
@@ -89,7 +89,7 @@ class ObservationRepositoryTest {
                         .setRRule(new RecurrenceRule().setFreq("DAILY").setCount(7)))
                 .setHidden(true)
                 .setNoSchedule(false)
-                .setObservationGroupId(observationGroupId1);
+                .setObservationGroupIds(Set.of(observationGroupId1));
 
         Observation observationResponse = observationRepository.insert(observation);
 
@@ -98,14 +98,14 @@ class ObservationRepositoryTest {
         assertThat(observationResponse.getProperties()).isEqualTo(observation.getProperties());
         assertThat(MapperUtils.writeValueAsString(observationResponse.getSchedule()))
                 .isEqualTo(MapperUtils.writeValueAsString(observation.getSchedule()));
-        assertThat(observationResponse.getObservationGroupId()).isEqualTo(observationGroupId1);
+        assertThat(observationResponse.getObservationGroupIds()).containsExactlyInAnyOrder(observationGroupId1);
 
         Integer oldId = observationResponse.getObservationId();
 
         observationResponse.setType("new type")
                 .setTitle("some new title")
                 .setSchedule(new Event().setDateEnd(Instant.now()).setDateEnd(Instant.now().plusSeconds(60)))
-                .setObservationGroupId(null);
+                .setObservationGroupIds(null); //assert that setting to NULL does not cause any problems
 
         Observation compareObservationResponse = observationRepository.updateObservation(observationResponse);
 
@@ -113,7 +113,7 @@ class ObservationRepositoryTest {
         assertThat(compareObservationResponse.getType()).isEqualTo(type);
         assertThat(compareObservationResponse.getObservationId()).isEqualTo(oldId);
         assertThat(compareObservationResponse.getSchedule()).isNotEqualTo(observation.getSchedule());
-        assertThat(observationResponse.getObservationGroupId()).isNull();
+        assertThat(observationResponse.getObservationGroupIds()).isEmpty();
 
         Observation observationResponse2 = observationRepository.insert(new Observation()
                 .setStudyId(studyId)
@@ -128,20 +128,32 @@ class ObservationRepositoryTest {
                 .setType("new Title - obs-group 1")
                 .setHidden(true)
                 .setNoSchedule(true)
-                .setObservationGroupId(observationGroupId1)
+                .setObservationGroupIds(Set.of(observationGroupId1))
         );
         Observation observationResponse3b = observationRepository.insert(new Observation()
                 .setStudyId(studyId)
                 .setType("gps")
-                .setType("new Title 2")
+                .setType("new Title 2 - obs-group 2")
                 .setHidden(true)
                 .setNoSchedule(true)
-                .setObservationGroupId(observationGroupId2)
+                .setObservationGroupIds(Set.of(observationGroupId2))
         );
+        Observation observationResponse3c = observationRepository.insert(new Observation()
+                .setStudyId(studyId)
+                .setType("gps")
+                .setType("new Title 2 - obs-group 1 & 2")
+                .setHidden(true)
+                .setNoSchedule(true)
+                .setObservationGroupIds(Set.of(observationGroupId1, observationGroupId2))
+        );
+
+        //test that multiple ObservationGroup assignments are correctly returned
+        assertThat(observationRepository.getById(studyId, observationResponse3c.getObservationId()).getObservationGroupIds())
+                .containsExactlyInAnyOrder(observationGroupId1, observationGroupId2);
 
         assertThat(observationRepository.listObservations(studyId))
                 .as("List all Observations")
-                .hasSize(4);
+                .hasSize(5);
 
         assertThat(observationRepository.listObservationsForGroup(studyId, studyGroupId))
                 .as("Include group-specific observations and globals") //NOTE: and in no observation group
@@ -166,18 +178,19 @@ class ObservationRepositoryTest {
         //this is true for obs2 (no group at all) and obs3 (in the correct observation group)
         assertThat(observationRepository.listObservationsForGroup(studyId, null, Set.of(observationGroupId1)))
                 .as("Obseration-Group should only retrieve observation in that observation group")
-                .hasSize(2)
+                .hasSize(3)
                 .extracting(Observation::getObservationId)
-                .containsExactly(observationResponse2.getObservationId(), observationResponse3a.getObservationId());
+                .containsExactly(observationResponse2.getObservationId(), observationResponse3a.getObservationId(), observationResponse3c.getObservationId());
 
 
         //list Observations for study-group '-1' and no observation-group of observation-group 'observationGroupId1' ->
         // This is true for all expect 'obs1'
         assertThat(observationRepository.listObservationsForGroup(studyId, -1, Set.of(observationGroupId1, observationGroupId2)))
                 .as("Obseration-Group should only retrieve observation in that observation group")
-                .hasSize(3)
+                .hasSize(4)
                 .extracting(Observation::getObservationId)
-                .containsExactly(observationResponse2.getObservationId(), observationResponse3a.getObservationId(), observationResponse3b.getObservationId());
+                .containsExactly(observationResponse2.getObservationId(),
+                        observationResponse3a.getObservationId(), observationResponse3b.getObservationId(), observationResponse3c.getObservationId());
 
         //test relative events
         observation.setSchedule(new RelativeEvent()
@@ -189,21 +202,21 @@ class ObservationRepositoryTest {
 
         //assert delete Observation Group sets property of Observation to null
         observationGroupRepository.deleteById(studyId, observationGroupId1);
-        assertThat((observationRepository.getById(studyId, observationResponse3a.getObservationId()).getObservationGroupId()))
-                .isNull();
+        assertThat((observationRepository.getById(studyId, observationResponse3a.getObservationId()).getObservationGroupIds()))
+                .isEmpty();
 
         // Delete the group specific observations
         observationRepository.deleteObservation(studyId, observationResponse4.getObservationId());
         observationRepository.deleteObservation(studyId, observationResponse.getObservationId());
         assertThat((observationRepository.listObservations(studyId)))
-                .hasSize(3);
+                .hasSize(4);
         assertThat((observationRepository.listObservationsForGroup(studyId, studyGroupId)))
                 .hasSize(2) //now that we deleted observationGroupId1 -> observationResponse3a is also in no group
                 .extracting(Observation::getObservationId)
                 .containsExactly(observationResponse2.getObservationId(), observationResponse3a.getObservationId());
         observationRepository.deleteObservation(studyId, observationResponse2.getObservationId());
         assertThat((observationRepository.listObservations(studyId)))
-                .hasSize(2);
+                .hasSize(3);
 
     }
 

--- a/studymanager/src/main/java/io/redlink/more/studymanager/model/transformer/InterventionTransformer.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/model/transformer/InterventionTransformer.java
@@ -25,7 +25,7 @@ public final class InterventionTransformer {
                 .setPurpose(dto.getPurpose())
                 .setStudyGroupId(dto.getStudyGroupId())
                 .setSchedule(EventTransformer.fromObservationScheduleDTO_V1(dto.getSchedule()))
-                .setObservationGroupId(dto.getObservationGroupId());
+                .setObservationGroupIds(dto.getObservationGroupIds());
     }
 
     public static InterventionDTO toInterventionDTO_V1(Intervention intervention) {
@@ -38,7 +38,7 @@ public final class InterventionTransformer {
                 .purpose(intervention.getPurpose())
                 .studyGroupId(intervention.getStudyGroupId())
                 .schedule(EventTransformer.toObservationScheduleDTO_V1(intervention.getSchedule()))
-                .observationGroupId(intervention.getObservationGroupId())
+                .observationGroupIds(intervention.getObservationGroupIds())
                 .created(instant1)
                 .modified(instant);
     }

--- a/studymanager/src/main/java/io/redlink/more/studymanager/model/transformer/ObservationTransformer.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/model/transformer/ObservationTransformer.java
@@ -32,7 +32,7 @@ public final class ObservationTransformer {
                 .setSchedule(EventTransformer.fromObservationScheduleDTO_V1(dto.getSchedule()))
                 .setHidden(dto.getHidden())
                 .setNoSchedule(dto.getNoSchedule())
-                .setObservationGroupId(dto.getObservationGroupId());
+                .setObservationGroupIds(dto.getObservationGroupIds());
     }
 
     public static ObservationDTO toObservationDTO_V1(Observation observation) {
@@ -52,7 +52,7 @@ public final class ObservationTransformer {
                 .modified(instant)
                 .hidden(observation.getHidden())
                 .noSchedule(observation.getNoSchedule())
-                .observationGroupId(observation.getObservationGroupId());
+                .observationGroupIds(observation.getObservationGroupIds());
     }
 
 }

--- a/studymanager/src/main/resources/openapi/StudyManagerAPI.yaml
+++ b/studymanager/src/main/resources/openapi/StudyManagerAPI.yaml
@@ -514,7 +514,7 @@ paths:
         - $ref: '#/components/parameters/StudyId'
       responses:
         '200':
-          description: Successfully listed all study groups
+          description: Successfully listed all observation groups
           content:
             application/json:
               schema:
@@ -1779,6 +1779,12 @@ components:
         numberOfParticipants:
           type: integer
           readOnly: true
+        numberOfObservations:
+          type: integer
+          readOnly: true
+        numberOfInterventions:
+          type: integer
+          readOnly: true
         created:
           type: string
           format: date-time
@@ -1787,6 +1793,8 @@ components:
           type: string
           format: date-time
           readOnly: true
+      required:
+        - title
     StudyDuration:
       type: object
       properties:
@@ -1893,8 +1901,12 @@ components:
         noSchedule:
           type: boolean
           default: false
-        observationGroupId:
-          $ref: '#/components/schemas/IdReference'
+        observationGroupIds:
+          type: array
+          description: The set of observation group Ids the observation is part of
+          items:
+            $ref: '#/components/schemas/IdReference'
+          uniqueItems: true
 
     OccurredObservation:
       type: object
@@ -2121,8 +2133,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Action'
-        observationGroupId:
-          $ref: '#/components/schemas/IdReference'
+        observationGroupIds:
+          type: array
+          description: The set of observation group Ids the intervention is part of
+          items:
+            $ref: '#/components/schemas/IdReference'
+          uniqueItems: true
         created:
           type: string
           format: date-time

--- a/studymanager/src/test/java/io/redlink/more/studymanager/controller/studymanager/InterventionControllerTest.java
+++ b/studymanager/src/test/java/io/redlink/more/studymanager/controller/studymanager/InterventionControllerTest.java
@@ -27,6 +27,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.EnumSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -92,7 +93,7 @@ class InterventionControllerTest {
                         .setSchedule(new Event()
                                 .setDateStart(dateStart)
                                 .setDateEnd(dateEnd))
-                        .setObservationGroupId(((Intervention)invocationOnMock.getArgument(0)).getObservationGroupId())
+                        .setObservationGroupIds(((Intervention)invocationOnMock.getArgument(0)).getObservationGroupIds())
                         .setCreated(Instant.now())
                         .setModified(Instant.now()));
 
@@ -105,7 +106,7 @@ class InterventionControllerTest {
                 .schedule(new EventDTO()
                         .dtstart(dateStart)
                         .dtend(dateEnd))
-                .observationGroupId(1);
+                .observationGroupIds(Set.of(1));
 
         mvc.perform(post("/api/v1/studies/1/interventions")
                         .content(mapper.writeValueAsString(interventionRequest))
@@ -115,7 +116,9 @@ class InterventionControllerTest {
                 .andExpect(jsonPath("$.title").value(interventionRequest.getTitle()))
                 .andExpect(jsonPath("$.interventionId").value(interventionRequest.getInterventionId()))
                 .andExpect(jsonPath("$.schedule").exists())
-                .andExpect(jsonPath("$.observationGroupId").value(interventionRequest.getObservationGroupId()));
+                .andExpect(jsonPath("$.observationGroupIds").isArray())
+                .andExpect(jsonPath("$.observationGroupIds[0]").value(interventionRequest.getObservationGroupIds().iterator().next()));
+
     }
 
     @Test

--- a/studymanager/src/test/java/io/redlink/more/studymanager/controller/studymanager/ObservationControllerTest.java
+++ b/studymanager/src/test/java/io/redlink/more/studymanager/controller/studymanager/ObservationControllerTest.java
@@ -22,11 +22,8 @@ import io.redlink.more.studymanager.service.OAuth2AuthenticationService;
 import io.redlink.more.studymanager.service.ObservationService;
 import io.redlink.more.studymanager.utils.MapperUtils;
 import java.time.Instant;
-import java.util.EnumSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -95,7 +92,7 @@ class ObservationControllerTest {
                         .setCreated(Instant.ofEpochMilli(System.currentTimeMillis()))
                         .setModified(Instant.ofEpochMilli(System.currentTimeMillis()))
                         .setHidden(((Observation) invocationOnMock.getArgument(0)).getHidden())
-                        .setObservationGroupId(((Observation) invocationOnMock.getArgument(0)).getObservationGroupId()));
+                        .setObservationGroupIds(((Observation) invocationOnMock.getArgument(0)).getObservationGroupIds()));
 
         ObservationDTO observationRequest = new ObservationDTO()
                 .title("observation 1")
@@ -107,7 +104,7 @@ class ObservationControllerTest {
                 .properties(Map.of("name", "value"))
                 .studyGroupId(1)
                 .hidden(null)
-                .observationGroupId(1);
+                .observationGroupIds(Set.of(1));
 
         mvc.perform(post("/api/v1/studies/1/observations")
                         .content(mapper.writeValueAsString(observationRequest))
@@ -119,7 +116,8 @@ class ObservationControllerTest {
                 .andExpect(jsonPath("$.type").value(observationRequest.getType()))
                 .andExpect(jsonPath("$.properties.name").value("value"))
                 .andExpect(jsonPath("$.hidden").value(observationRequest.getHidden()))
-                .andExpect(jsonPath("$.observationGroupId").value(observationRequest.getObservationGroupId()));
+                .andExpect(jsonPath("$.observationGroupIds").isArray())
+                .andExpect(jsonPath("$.observationGroupIds[0]").value(observationRequest.getObservationGroupIds().iterator().next()));
     }
 
     @Test

--- a/studymanager/src/test/java/io/redlink/more/studymanager/service/ImportExportServiceTest.java
+++ b/studymanager/src/test/java/io/redlink/more/studymanager/service/ImportExportServiceTest.java
@@ -123,7 +123,7 @@ public class ImportExportServiceTest {
                                 .setStudyGroupId(3)
                                 .setProperties(new ObservationProperties())
                                 .setSchedule(new Event())
-                                .setObservationGroupId(1),
+                                .setObservationGroupIds(Set.of(1)),
                         new Observation()
                                 .setObservationId(3)
                                 .setTitle("observation Title")
@@ -133,7 +133,17 @@ public class ImportExportServiceTest {
                                 .setStudyGroupId(null)
                                 .setProperties(new ObservationProperties())
                                 .setSchedule(new Event())
-                                .setObservationGroupId(2)))
+                                .setObservationGroupIds(Set.of(2)),
+                        new Observation()
+                                .setObservationId(4)
+                                .setTitle("observation Title")
+                                .setPurpose("observation purpose")
+                                .setParticipantInfo("observation info")
+                                .setType("gps-mobile-observation")
+                                .setStudyGroupId(null)
+                                .setProperties(new ObservationProperties())
+                                .setSchedule(new Event())
+                                .setObservationGroupIds(Set.of(1,2))))
                 .setStudyGroups(List.of(
                         new StudyGroup()
                                 .setStudyGroupId(2)
@@ -159,14 +169,21 @@ public class ImportExportServiceTest {
                                 .setPurpose("intervention purpose")
                                 .setStudyGroupId(2)
                                 .setSchedule(new Event())
-                                .setObservationGroupId(1),
+                                .setObservationGroupIds(Set.of(1)),
                         new Intervention()
                                 .setInterventionId(3)
                                 .setTitle("intervention title")
                                 .setPurpose("intervention purpose")
                                 .setStudyGroupId(3)
                                 .setSchedule(new Event())
-                                .setObservationGroupId(2)))
+                                .setObservationGroupIds(Set.of(2)),
+                        new Intervention()
+                                .setInterventionId(4)
+                                .setTitle("intervention title")
+                                .setPurpose("intervention purpose")
+                                .setStudyGroupId(3)
+                                .setSchedule(new Event())
+                                .setObservationGroupIds(Set.of(1,2))))
                 .setTriggers(Map.of(3, new Trigger()
                         .setType("sth")
                         .setProperties(new TriggerProperties())))
@@ -213,24 +230,30 @@ public class ImportExportServiceTest {
         assertThat(studyGroupCaptor.getAllValues().get(1).getStudyGroupId()).isEqualTo(3);
 
 
-        verify(observationService, times(2)).importObservation(idLongCaptor.capture(), observationCaptor.capture());
-        verify(interventionService, times(2)).importIntervention(idLongCaptor.capture(), interventionCaptor.capture(), triggerCaptor.capture(), actionCaptor.capture());
+        verify(observationService, times(3)).importObservation(idLongCaptor.capture(), observationCaptor.capture());
+        verify(interventionService, times(3)).importIntervention(idLongCaptor.capture(), interventionCaptor.capture(), triggerCaptor.capture(), actionCaptor.capture());
         verify(participantService, times(8)).createParticipant(participantsCaptor.capture());
         verify(integrationService, times(2)).addToken(idLongCaptor.capture(), idIntegerCaptor.capture(), aliasCaptor.capture());
 
         assertThat(observationCaptor.getAllValues().get(0).getObservationId()).isEqualTo(1);
         assertThat(observationCaptor.getAllValues().get(0).getStudyGroupId()).isEqualTo(3);
-        assertThat(observationCaptor.getAllValues().get(0).getObservationGroupId()).isEqualTo(1);
+        assertThat(observationCaptor.getAllValues().get(0).getObservationGroupIds()).containsExactlyInAnyOrder(1);
         assertThat(observationCaptor.getAllValues().get(1).getObservationId()).isEqualTo(3);
-        assertThat(observationCaptor.getAllValues().get(1).getStudyGroupId()).isEqualTo(null);
-        assertThat(observationCaptor.getAllValues().get(1).getObservationGroupId()).isEqualTo(2);
+        assertThat(observationCaptor.getAllValues().get(1).getStudyGroupId()).isNull();
+        assertThat(observationCaptor.getAllValues().get(1).getObservationGroupIds()).containsExactlyInAnyOrder(2);
+        assertThat(observationCaptor.getAllValues().get(2).getObservationId()).isEqualTo(4);
+        assertThat(observationCaptor.getAllValues().get(2).getStudyGroupId()).isNull();
+        assertThat(observationCaptor.getAllValues().get(2).getObservationGroupIds()).containsExactlyInAnyOrder(1, 2);
 
-        assertThat(interventionCaptor.getAllValues().get(0).getStudyGroupId()).isEqualTo(2);
         assertThat(interventionCaptor.getAllValues().get(0).getInterventionId()).isEqualTo(2);
-        assertThat(interventionCaptor.getAllValues().get(0).getObservationGroupId()).isEqualTo(1);
-        assertThat(interventionCaptor.getAllValues().get(1).getStudyGroupId()).isEqualTo(3);
+        assertThat(interventionCaptor.getAllValues().get(0).getStudyGroupId()).isEqualTo(2);
+        assertThat(interventionCaptor.getAllValues().get(0).getObservationGroupIds()).containsExactlyInAnyOrder(1);
         assertThat(interventionCaptor.getAllValues().get(1).getInterventionId()).isEqualTo(3);
-        assertThat(interventionCaptor.getAllValues().get(1).getObservationGroupId()).isEqualTo(2);
+        assertThat(interventionCaptor.getAllValues().get(1).getStudyGroupId()).isEqualTo(3);
+        assertThat(interventionCaptor.getAllValues().get(1).getObservationGroupIds()).containsExactlyInAnyOrder(2);
+        assertThat(interventionCaptor.getAllValues().get(2).getInterventionId()).isEqualTo(4);
+        assertThat(interventionCaptor.getAllValues().get(2).getStudyGroupId()).isEqualTo(3);
+        assertThat(interventionCaptor.getAllValues().get(2).getObservationGroupIds()).containsExactlyInAnyOrder(1, 2);
 
         assertThat(idLongCaptor.getAllValues()).allMatch(Predicate.isEqual(1L));
 


### PR DESCRIPTION
This Pull Requests covers:

* [umm-project/#249](https://github.com/redlink-gmbh/umm-project/issues/249): Extension to the MORE database and Repositories to allow for multiple `ObservationGroup` assignments to `Observation` and `Intervention`
* [umm-project/#250](https://github.com/redlink-gmbh/umm-project/issues/250): Replaces the merge Request with only the API extensions
* [umm-project/#251](https://github.com/redlink-gmbh/umm-project/issues/251): Implementation of the API extensions as defined by [umm-project/#250](https://github.com/redlink-gmbh/umm-project/issues/250)

