### PR TITLE
#251: Add member counts for ObservationGroups

### DIFF
--- a/studymanager-services/src/main/java/io/redlink/more/studymanager/repository/ObservationGroupRepository.java
+++ b/studymanager-services/src/main/java/io/redlink/more/studymanager/repository/ObservationGroupRepository.java
@@ -32,6 +32,41 @@ public class ObservationGroupRepository {
     private static final String DELETE_OBSERVATION_GROUP_BY_ID = "DELETE FROM observation_groups WHERE study_id = ? AND observation_group_id = ?";
     private static final String CLEAR_OBSERVATION_GROUPS = "DELETE FROM observation_groups";
 
+    private static final String COUNT_OBSERVATIONS_IN_GROUP = """
+        SELECT COUNT(*) FROM observation_observation_groups
+        WHERE study_id = :study_id AND observation_group_id = :observation_group_id""";
+    private static final String COUNT_INTERVENTIONS_IN_GROUP = """
+        SELECT COUNT(*) FROM intervention_observation_groups
+        WHERE study_id = :study_id AND observation_group_id = :observation_group_id""";
+    private static final String COUNT_PARTICIPANTS_IN_GROUP = """
+        SELECT COUNT(*) FROM participant_observation_groups
+        WHERE study_id = :study_id AND observation_group_id = :observation_group_id""";
+    public static final String ADD_OBSERVATION_TO_OBSERVATION_GROUP = """
+        INSERT INTO observation_observation_groups (study_id, observation_id, observation_group_id)
+        VALUES (:study_id, :observation_id, :observation_group_id)
+        ON CONFLICT DO NOTHING""";
+    private static final String REMOVE_OBSERVATION_FROM_GROUP = """
+        DELETE FROM observation_observation_groups
+        WHERE study_id = :study_id AND observation_id = :observation_id
+            AND observation_group_id = :observation_group_id""";
+    private static final String ADD_INTERVENTION_TO_GROUP = """
+        INSERT INTO intervention_observation_groups (study_id, intervention_id, observation_group_id)
+        VALUES (:study_id, :intervention_id, :observation_group_id)
+        ON CONFLICT DO NOTHING""";
+    private static final String REMOVE_INTERVENTION_FROM_GROUP = """
+        DELETE FROM intervention_observation_groups
+        WHERE study_id = :study_id AND intervention_id = :intervention_id
+            AND observation_group_id = :observation_group_id""";
+    private static final String ADD_PARTICIPANT_TO_GROUP = """
+        INSERT INTO participant_observation_groups (study_id, participant_id, observation_group_id)
+        VALUES (:study_id, :participant_id, :observation_group_id)
+        ON CONFLICT DO NOTHING""";
+    private static final String REMOVE_PARTICIPANT_FROM_GROUP = """
+        DELETE FROM participant_observation_groups
+        WHERE study_id = :study_id AND participant_id = :participant_id AND observation_group_id = :observation_group_id""";
+
+
+
     private final JdbcTemplate template;
     private final NamedParameterJdbcTemplate namedTemplate;
 
@@ -88,6 +123,139 @@ public class ObservationGroupRepository {
 
     public void deleteById(long studyId, int observationGroupId) {
         template.update(DELETE_OBSERVATION_GROUP_BY_ID, studyId, observationGroupId);
+    }
+
+
+    /**
+     * Add an observation to an observation group.
+     *
+     * @param studyId the ID of the study
+     * @param observationId the ID of the observation
+     * @param observationGroupId the ID of the observation group
+     */
+    public void addObservationToGroup(long studyId, int observationId, int observationGroupId) {
+        namedTemplate.update(
+                ADD_OBSERVATION_TO_OBSERVATION_GROUP,
+                toParams(studyId, observationGroupId)
+                        .addValue("observation_id", observationId));
+    }
+
+    /**
+     * Remove an observation from an observation group.
+     *
+     * @param studyId the ID of the study
+     * @param observationId the ID of the observation
+     * @param observationGroupId the ID of the observation group
+     */
+    public void removeObservationFromGroup(long studyId, int observationId, int observationGroupId) {
+        namedTemplate.update(
+                REMOVE_OBSERVATION_FROM_GROUP,
+                toParams(studyId, observationGroupId)
+                        .addValue("observation_id", observationId));
+    }
+
+    /**
+     * Add an intervention to an observation group.
+     *
+     * @param studyId the ID of the study
+     * @param interventionId the ID of the intervention
+     * @param observationGroupId the ID of the observation group
+     */
+    public void addInterventionToGroup(long studyId, int interventionId, int observationGroupId) {
+        namedTemplate.update(
+                ADD_INTERVENTION_TO_GROUP,
+                toParams(studyId, observationGroupId)
+                        .addValue("intervention_id", interventionId));
+    }
+
+    /**
+     * Remove an intervention from an observation group.
+     *
+     * @param studyId the ID of the study
+     * @param interventionId the ID of the intervention
+     * @param observationGroupId the ID of the observation group
+     */
+    public void removeInterventionFromGroup(long studyId, int interventionId, int observationGroupId) {
+        namedTemplate.update(
+                REMOVE_INTERVENTION_FROM_GROUP,
+                toParams(studyId, observationGroupId)
+                        .addValue("intervention_id", interventionId));
+    }
+
+    /**
+     * Add a participant to an observation group.
+     *
+     * @param studyId the ID of the study
+     * @param participantId the ID of the participant
+     * @param observationGroupId the ID of the observation group
+     */
+    public void addParticipantToGroup(long studyId, int participantId, int observationGroupId) {
+        namedTemplate.update(
+                ADD_PARTICIPANT_TO_GROUP,
+                toParams(studyId, observationGroupId)
+                        .addValue("participant_id", participantId));
+    }
+
+    /**
+     * Remove a participant from an observation group.
+     *
+     * @param studyId the ID of the study
+     * @param participantId the ID of the participant
+     * @param observationGroupId the ID of the observation group
+     */
+    public void removeParticipantFromGroup(long studyId, int participantId, int observationGroupId) {
+        namedTemplate.update(
+                REMOVE_PARTICIPANT_FROM_GROUP,
+                toParams(studyId, observationGroupId)
+                        .addValue("participant_id", participantId));
+    }
+
+    /**
+     * Count the number of observations in an observation group.
+     *
+     * @param studyId the ID of the study
+     * @param observationGroupId the ID of the observation group
+     * @return the count
+     */
+    public int countObservationsInGroup(long studyId, int observationGroupId) {
+        return namedTemplate.queryForObject(
+                COUNT_OBSERVATIONS_IN_GROUP,
+                toParams(studyId, observationGroupId),
+                Integer.class);
+    }
+
+    /**
+     * Count the number of interventions in an observation group.
+     *
+     * @param studyId the ID of the study
+     * @param observationGroupId the ID of the observation group
+     * @return the count
+     */
+    public int countInterventionsInGroup(long studyId, int observationGroupId) {
+        return namedTemplate.queryForObject(
+                COUNT_INTERVENTIONS_IN_GROUP,
+                toParams(studyId, observationGroupId),
+                Integer.class);
+    }
+
+    /**
+     * Count the number of participants in an observation group.
+     *
+     * @param studyId the ID of the study
+     * @param observationGroupId the ID of the observation group
+     * @return the count
+     */
+    public int countParticipantsInGroup(long studyId, int observationGroupId) {
+        return namedTemplate.queryForObject(
+                COUNT_PARTICIPANTS_IN_GROUP,
+                toParams(studyId, observationGroupId),
+                Integer.class);
+    }
+
+    private static MapSqlParameterSource toParams(long studyId, int observationGroupId) {
+        return new MapSqlParameterSource()
+                .addValue("study_id", studyId)
+                .addValue("observation_group_id", observationGroupId);
     }
 
     private static MapSqlParameterSource toParams(ObservationGroup observationGroup) {

--- a/studymanager-services/src/main/java/io/redlink/more/studymanager/service/ObservationGroupService.java
+++ b/studymanager-services/src/main/java/io/redlink/more/studymanager/service/ObservationGroupService.java
@@ -55,4 +55,56 @@ public class ObservationGroupService {
         studyStateService.assertStudyNotInState(studyId, Study.Status.CLOSED);
         this.repository.deleteById(studyId, observationGroupId);
     }
+
+    public void addObservationToGroup(long studyId, int observationGroupId, int observationId) {
+        studyStateService.assertStudyNotInState(studyId, Study.Status.CLOSED);
+        getObservationGroup(studyId, observationGroupId);
+        repository.addObservationToGroup(studyId, observationId, observationGroupId);
+    }
+
+    public void addInterventionToGroup(long studyId, int observationGroupId, int interventionId) {
+        studyStateService.assertStudyNotInState(studyId, Study.Status.CLOSED);
+        getObservationGroup(studyId, observationGroupId);
+        repository.addInterventionToGroup(studyId, interventionId, observationGroupId);
+    }
+
+    public void addParticipantToGroup(long studyId, int observationGroupId, int participantId) {
+        studyStateService.assertStudyNotInState(studyId, Study.Status.CLOSED);
+        getObservationGroup(studyId, observationGroupId);
+        repository.addParticipantToGroup(studyId, participantId, observationGroupId);
+    }
+
+    public void removeObservationFromGroup(long studyId, int observationGroupId, int observationId) {
+        studyStateService.assertStudyNotInState(studyId, Study.Status.CLOSED);
+        getObservationGroup(studyId, observationGroupId);
+        repository.removeObservationFromGroup(studyId, observationId, observationGroupId);
+    }
+
+    public void removeInterventionFromGroup(long studyId, int observationGroupId, int interventionId) {
+        studyStateService.assertStudyNotInState(studyId, Study.Status.CLOSED);
+        getObservationGroup(studyId, observationGroupId);
+        repository.removeInterventionFromGroup(studyId, interventionId, observationGroupId);
+    }
+
+    public void removeParticipantFromGroup(long studyId, int observationGroupId, int participantId) {
+        studyStateService.assertStudyNotInState(studyId, Study.Status.CLOSED);
+        getObservationGroup(studyId, observationGroupId);
+        repository.removeParticipantFromGroup(studyId, participantId, observationGroupId);
+    }
+
+    public int countObservationsInGroup(long studyId, int observationGroupId) {
+        //getObservationGroup(studyId, observationGroupId);
+        return repository.countObservationsInGroup(studyId, observationGroupId);
+    }
+
+    public int countInterventionsInGroup(long studyId, int observationGroupId) {
+        //getObservationGroup(studyId, observationGroupId);
+        return repository.countInterventionsInGroup(studyId, observationGroupId);
+    }
+
+    public int countParticipantsInGroup(long studyId, int observationGroupId) {
+        //getObservationGroup(studyId, observationGroupId);
+        return repository.countParticipantsInGroup(studyId, observationGroupId);
+    }
+
 }

--- a/studymanager-services/src/test/java/io/redlink/more/studymanager/repository/ObservationGroupRepositoryTest.java
+++ b/studymanager-services/src/test/java/io/redlink/more/studymanager/repository/ObservationGroupRepositoryTest.java
@@ -154,6 +154,7 @@ class ObservationGroupRepositoryTest {
                 .setPurpose("Test Purpose")
                 .setParticipantInfo("Info")
                 .setType("questionnaire")
+                .setHidden(false)
                 .setProperties(new ObservationProperties())
                 .setSchedule(null); // Assuming null is allowed
         Observation obsResp = observationRepository.insert(obs);
@@ -171,7 +172,8 @@ class ObservationGroupRepositoryTest {
         // Create participant
         Participant p = new Participant()
                 .setStudyId(studyId)
-                .setAlias("Test Participant");
+                .setAlias("Test Participant")
+                .setRegistrationToken("rt_p1");
         Participant pResp = participantRepository.insert(p);
         int pId = pResp.getParticipantId();
 

--- a/studymanager-services/src/test/java/io/redlink/more/studymanager/repository/ObservationGroupRepositoryTest.java
+++ b/studymanager-services/src/test/java/io/redlink/more/studymanager/repository/ObservationGroupRepositoryTest.java
@@ -38,6 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EnableAutoConfiguration
 @ContextConfiguration(classes = {
         ObservationGroupRepository.class, StudyRepository.class,
+        ObservationRepository.class, InterventionRepository.class, ParticipantRepository.class,
         JPAConfiguration.class
 })
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
@@ -50,9 +51,21 @@ class ObservationGroupRepositoryTest {
     @Autowired
     private StudyRepository studyRepository;
 
+    @Autowired
+    private ObservationRepository observationRepository;
+
+    @Autowired
+    private InterventionRepository interventionRepository;
+
+    @Autowired
+    private ParticipantRepository participantRepository;
+
     @BeforeEach
     void deleteAll() {
         observationGroupRepository.clear();
+        observationRepository.clear();
+        interventionRepository.clear();
+        participantRepository.clear();
     }
 
     @Test
@@ -122,4 +135,80 @@ class ObservationGroupRepositoryTest {
         assertThat(observationGroupRepository.listObservationGroupsOrderedByObservationGroupIdAsc(studyId))
                 .hasSize(1);
     }
+
+    @Test
+    @DisplayName("Adding, removing and counting members in observation groups")
+    public void testGroupMemberships() {
+        Long studyId = studyRepository.insert(new Study().setContact(new Contact().setPerson("test").setEmail("test"))).getStudyId();
+
+        ObservationGroup og = observationGroupRepository.insert(new ObservationGroup()
+                .setStudyId(studyId)
+                .setTitle("Test Group")
+                .setPurpose("Test Purpose"));
+        int ogId = og.getObservationGroupId();
+
+        // Create observation
+        Observation obs = new Observation()
+                .setStudyId(studyId)
+                .setTitle("Test Observation")
+                .setPurpose("Test Purpose")
+                .setParticipantInfo("Info")
+                .setType("questionnaire")
+                .setProperties(new ObservationProperties())
+                .setSchedule(null); // Assuming null is allowed
+        Observation obsResp = observationRepository.insert(obs);
+        int obsId = obsResp.getObservationId();
+
+        // Create intervention
+        Intervention intv = new Intervention()
+                .setStudyId(studyId)
+                .setTitle("Test Intervention")
+                .setPurpose("Test Purpose")
+                .setSchedule(null); // Assuming null is allowed
+        Intervention intvResp = interventionRepository.insert(intv);
+        int intvId = intvResp.getInterventionId();
+
+        // Create participant
+        Participant p = new Participant()
+                .setStudyId(studyId)
+                .setAlias("Test Participant");
+        Participant pResp = participantRepository.insert(p);
+        int pId = pResp.getParticipantId();
+
+        // Initial counts should be 0
+        assertThat(observationGroupRepository.countObservationsInGroup(studyId, ogId)).isEqualTo(0);
+        assertThat(observationGroupRepository.countInterventionsInGroup(studyId, ogId)).isEqualTo(0);
+        assertThat(observationGroupRepository.countParticipantsInGroup(studyId, ogId)).isEqualTo(0);
+
+        // Add to group
+        observationGroupRepository.addObservationToGroup(studyId, obsId, ogId);
+        observationGroupRepository.addInterventionToGroup(studyId, intvId, ogId);
+        observationGroupRepository.addParticipantToGroup(studyId, pId, ogId);
+
+        // Counts should be 1
+        assertThat(observationGroupRepository.countObservationsInGroup(studyId, ogId)).isEqualTo(1);
+        assertThat(observationGroupRepository.countInterventionsInGroup(studyId, ogId)).isEqualTo(1);
+        assertThat(observationGroupRepository.countParticipantsInGroup(studyId, ogId)).isEqualTo(1);
+
+        // Add again (should not increase due to ON CONFLICT DO NOTHING)
+        observationGroupRepository.addObservationToGroup(studyId, obsId, ogId);
+        observationGroupRepository.addInterventionToGroup(studyId, intvId, ogId);
+        observationGroupRepository.addParticipantToGroup(studyId, pId, ogId);
+
+        // Counts still 1
+        assertThat(observationGroupRepository.countObservationsInGroup(studyId, ogId)).isEqualTo(1);
+        assertThat(observationGroupRepository.countInterventionsInGroup(studyId, ogId)).isEqualTo(1);
+        assertThat(observationGroupRepository.countParticipantsInGroup(studyId, ogId)).isEqualTo(1);
+
+        // Remove from group
+        observationGroupRepository.removeObservationFromGroup(studyId, obsId, ogId);
+        observationGroupRepository.removeInterventionFromGroup(studyId, intvId, ogId);
+        observationGroupRepository.removeParticipantFromGroup(studyId, pId, ogId);
+
+        // Counts should be 0
+        assertThat(observationGroupRepository.countObservationsInGroup(studyId, ogId)).isEqualTo(0);
+        assertThat(observationGroupRepository.countInterventionsInGroup(studyId, ogId)).isEqualTo(0);
+        assertThat(observationGroupRepository.countParticipantsInGroup(studyId, ogId)).isEqualTo(0);
+    }
+
 }

--- a/studymanager/src/main/java/io/redlink/more/studymanager/controller/studymanager/ObservationGroupApiV1Controller.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/controller/studymanager/ObservationGroupApiV1Controller.java
@@ -49,7 +49,7 @@ public class ObservationGroupApiV1Controller implements ObservationGroupsApi {
         );
         LOGGER.debug("ObservationGroup created: {}", observationGroup);
         return ResponseEntity.status(HttpStatus.CREATED).body(
-                ObservationGroupTransformer.toObservationGroupDTO_V1(observationGroup)
+                ObservationGroupTransformer.toObservationGroupDTO_V1(observationGroup,0,0,0)
         );
     }
 
@@ -59,7 +59,11 @@ public class ObservationGroupApiV1Controller implements ObservationGroupsApi {
     public ResponseEntity<List<ObservationGroupDTO>> listObservationGroups(Long studyId) {
         return ResponseEntity.ok(
                 service.listObservationGroups(studyId).stream()
-                        .map(ObservationGroupTransformer::toObservationGroupDTO_V1)
+                        .map(og -> ObservationGroupTransformer.toObservationGroupDTO_V1(
+                            og,
+                            service.countObservationsInGroup(studyId, og.getObservationGroupId()),
+                            service.countInterventionsInGroup(studyId, og.getObservationGroupId()),
+                            service.countParticipantsInGroup(studyId, og.getObservationGroupId())))
                         .toList()
         );
     }
@@ -68,9 +72,16 @@ public class ObservationGroupApiV1Controller implements ObservationGroupsApi {
     @RequiresStudyRole
     @Audited
     public ResponseEntity<ObservationGroupDTO> getObservationGroup(Long studyId, Integer observationGroupId) {
+        var og = service.getObservationGroup(studyId, observationGroupId);
+        if(og == null) {
+            return ResponseEntity.notFound().build();
+        }
         return ResponseEntity.ok(
-                ObservationGroupTransformer.toObservationGroupDTO_V1(service.getObservationGroup(studyId, observationGroupId))
-        );
+            ObservationGroupTransformer.toObservationGroupDTO_V1(
+                og,
+                service.countObservationsInGroup(og.getStudyId(), og.getObservationGroupId()),
+                service.countInterventionsInGroup(og.getStudyId(), og.getObservationGroupId()),
+                service.countParticipantsInGroup(og.getStudyId(), og.getObservationGroupId())));
     }
 
     @Override
@@ -79,13 +90,14 @@ public class ObservationGroupApiV1Controller implements ObservationGroupsApi {
     public ResponseEntity<ObservationGroupDTO> updateObservationGroup(Long studyId, Integer observationGroupId, ObservationGroupDTO observationGroupDTO) {
         observationGroupDTO.setStudyId(studyId);
         observationGroupDTO.setObservationGroupId(observationGroupId);
+        var og = service.updateObservationGroup(
+                ObservationGroupTransformer.fromObservationGroupDTO_V1(observationGroupDTO));
         return ResponseEntity.ok(
                 ObservationGroupTransformer.toObservationGroupDTO_V1(
-                        service.updateObservationGroup(
-                                ObservationGroupTransformer.fromObservationGroupDTO_V1(observationGroupDTO)
-                        )
-                )
-        );
+                        og,
+                        service.countObservationsInGroup(og.getStudyId(), og.getObservationGroupId()),
+                        service.countInterventionsInGroup(og.getStudyId(), og.getObservationGroupId()),
+                        service.countParticipantsInGroup(og.getStudyId(), og.getObservationGroupId())));
     }
 
     @Override

--- a/studymanager/src/main/java/io/redlink/more/studymanager/model/transformer/ObservationGroupTransformer.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/model/transformer/ObservationGroupTransformer.java
@@ -26,7 +26,12 @@ public final class ObservationGroupTransformer {
                 .setPurpose(ObservationGroupDTO.getPurpose());
     }
 
-    public static ObservationGroupDTO toObservationGroupDTO_V1(ObservationGroup ObservationGroup) {
+    public static ObservationGroupDTO toObservationGroupDTO_V1(
+            ObservationGroup ObservationGroup,
+            int observationCount,
+            int interventionCount,
+            int participantCount
+    ) {
         Instant instant = ObservationGroup.getModified();
         Instant instant1 = ObservationGroup.getCreated();
         return new ObservationGroupDTO()
@@ -34,6 +39,9 @@ public final class ObservationGroupTransformer {
                 .observationGroupId(ObservationGroup.getObservationGroupId())
                 .title(ObservationGroup.getTitle())
                 .purpose(ObservationGroup.getPurpose())
+                .numberOfObservations(observationCount)
+                .numberOfInterventions(interventionCount)
+                .numberOfParticipants(participantCount)
                 .created(instant1)
                 .modified(instant);
     }

--- a/studymanager/src/test/java/io/redlink/more/studymanager/controller/studymanager/ObservationGroupControllerTest.java
+++ b/studymanager/src/test/java/io/redlink/more/studymanager/controller/studymanager/ObservationGroupControllerTest.java
@@ -160,6 +160,22 @@ class ObservationGroupControllerTest {
                     );
         });
 
+        when(observationGroupService.countObservationsInGroup(anyLong(), anyInt())).thenAnswer(invocationOnMock -> {
+            Long studyId = ((Long) invocationOnMock.getArgument(0));
+            Integer groupId = ((Integer) invocationOnMock.getArgument(1));
+            return (studyId.intValue() + groupId) * 2;
+        });
+        when(observationGroupService.countInterventionsInGroup(anyLong(), anyInt())).thenAnswer(invocationOnMock -> {
+            Long studyId = ((Long) invocationOnMock.getArgument(0));
+            Integer groupId = ((Integer) invocationOnMock.getArgument(1));
+            return (studyId.intValue() + groupId) * 3;
+        });
+        when(observationGroupService.countParticipantsInGroup(anyLong(), anyInt())).thenAnswer(invocationOnMock -> {
+            Long studyId = ((Long) invocationOnMock.getArgument(0));
+            Integer groupId = ((Integer) invocationOnMock.getArgument(1));
+            return (studyId.intValue() + groupId) * 4;
+        });
+
         mvc.perform(get("/api/v1/studies/1/observationGroups"))
                 .andDo(print())
                 .andExpect(status().isOk())
@@ -169,12 +185,21 @@ class ObservationGroupControllerTest {
                 .andExpect(jsonPath("$[0].observationGroupId").value(1))
                 .andExpect(jsonPath("$[0].title").value("Observation group 1"))
                 .andExpect(jsonPath("$[0].purpose").value("purpose 1"))
+                .andExpect(jsonPath("$[0].numberOfObservations").value(4))
+                .andExpect(jsonPath("$[0].numberOfInterventions").value(6))
+                .andExpect(jsonPath("$[0].numberOfParticipants").value(8))
                 .andExpect(jsonPath("$[0].created").exists())
                 .andExpect(jsonPath("$[0].modified").exists())
                 .andExpect(jsonPath("$[1].studyId").value(1))
                 .andExpect(jsonPath("$[1].observationGroupId").value(2))
+                .andExpect(jsonPath("$[1].numberOfObservations").value(6))
+                .andExpect(jsonPath("$[1].numberOfInterventions").value(9))
+                .andExpect(jsonPath("$[1].numberOfParticipants").value(12))
                 .andExpect(jsonPath("$[2].studyId").value(1))
-                .andExpect(jsonPath("$[2].observationGroupId").value(3));
+                .andExpect(jsonPath("$[2].observationGroupId").value(3))
+                .andExpect(jsonPath("$[2].numberOfObservations").value(8))
+                .andExpect(jsonPath("$[2].numberOfInterventions").value(12))
+                .andExpect(jsonPath("$[2].numberOfParticipants").value(16));
     }
 
     @Test


### PR DESCRIPTION
#251: This adds functionality needed to provides the number of observation, interventions and participants in an observation groups; Also to add/remove observation, interventions and participants from observationGorups; Adds numberOf** information to ObservationGroups returned via the API