### PR TITLE
#271 [Bugfix] NPE if no observation group ids are present in the request

### DIFF
--- a/studymanager/src/main/java/io/redlink/more/studymanager/service/ImportExportService.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/service/ImportExportService.java
@@ -172,7 +172,7 @@ public class ImportExportService {
     public void exportStudyData(OutputStream outputStream, Long studyId, List<Integer> studyGroupId, List<Integer> observationGroupId, List<Integer> participantId, List<Integer> observationId, Instant from, Instant to) {
         if (studyService.existsStudy(studyId).orElse(false)) {
             Collection<Integer> selectedObservationIds;
-            if(!observationGroupId.isEmpty()){
+            if(observationGroupId != null && !observationGroupId.isEmpty()){
                 selectedObservationIds = observationService.listObservationsForGroup(studyId, null,observationGroupId)
                         .stream().map(Observation::getObservationId).collect(Collectors.toSet());
                 LOGGER.debug("Selected observation ids for parsed ObservationGroups: {}", selectedObservationIds);


### PR DESCRIPTION
Caused by the Controller as NULL is parsed if no observation group ids are parsed ... NULL and empty are now treated the same

This fixes the NPE encountered:

```
java.lang.NullPointerException: Cannot invoke \"java.util.List.isEmpty()\" because \"observationGroupId\" is null
    at io.redlink.more.studymanager.service.ImportExportService.exportStudyData(ImportExportService.java:175)
    at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
    at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
    at java.base/java.lang.reflect.Method.invoke(Unknown Source)
    at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:360)
    at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:724)
    at io.redlink.more.studymanager.service.ImportExportService$$SpringCGLIB$$0.exportStudyData(<generated>)
    at io.redlink.more.studymanager.controller.studymanager.ImportExportApiV1Controller.lambda$exportStudyData$1(ImportExportApiV1Controller.java:115)
    at org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBodyReturnValueHandler$StreamingResponseBodyTask.call(StreamingResponseBodyReturnValueHandler.java:110)
    at org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBodyReturnValueHandler$StreamingResponseBodyTask.call(StreamingResponseBodyReturnValueHandler.java:97)
    at org.springframework.web.context.request.async.WebAsyncManager.lambda$startCallableProcessing$4(WebAsyncManager.java:373)
    at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source)
    at java.base/java.util.concurrent.FutureTask.run(Unknown Source)
    at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
    at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
    at java.base/java.lang.Thread.run(Unknown Source)
```