### PR TITLE
#267: Wrong StudyId set for imported Observations and Interventions

### DIFF
--- a/studymanager-services/src/main/java/io/redlink/more/studymanager/repository/InterventionRepository.java
+++ b/studymanager-services/src/main/java/io/redlink/more/studymanager/repository/InterventionRepository.java
@@ -128,8 +128,8 @@ public class InterventionRepository {
                     intervention.getStudyId() + "(" + e.getClass().getSimpleName() + ": " + e.getMessage() + ")");
         }
         Integer interventionId = keyHolder.getKey().intValue();
-        setInverventionObservationGroupIds(intervention.getStudyId(), interventionId, intervention.getObservationGroupIds());
-        return getByIds(intervention.getStudyId(), interventionId);
+        setInverventionObservationGroupIds(studyId, interventionId, intervention.getObservationGroupIds());
+        return getByIds(studyId, interventionId);
     }
 
     public List<Intervention> listInterventions(Long studyId) {

--- a/studymanager-services/src/main/java/io/redlink/more/studymanager/repository/ObservationRepository.java
+++ b/studymanager-services/src/main/java/io/redlink/more/studymanager/repository/ObservationRepository.java
@@ -145,8 +145,8 @@ public class ObservationRepository {
             );
         }
         Integer observationId = keyHolder.getKey().intValue();
-        setObservationObservationGroupIds(observation.getStudyId(), observationId, observation.getObservationGroupIds());
-        return getById(observation.getStudyId(), observationId);
+        setObservationObservationGroupIds(studyId, observationId, observation.getObservationGroupIds());
+        return getById(studyId, observationId);
     }
 
     public Observation getById(Long studyId, Integer observationId) {

--- a/studymanager/src/main/java/io/redlink/more/studymanager/model/transformer/ImportExportTransformer.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/model/transformer/ImportExportTransformer.java
@@ -29,6 +29,7 @@ public final class ImportExportTransformer {
         return new StudyImportExport()
                 .setStudy(StudyTransformer.fromStudyDTO_V1(dto.getStudy()))
                 .setStudyGroups(transform(dto.getStudyGroups(), StudyGroupTransformer::fromStudyGroupDTO_V1))
+                .setObservationGroups(transform(dto.getObservationGroups(), ObservationGroupTransformer::fromObservationGroupDTO_V1))
                 .setObservations(transform(dto.getObservations(), ObservationTransformer::fromObservationDTO_V1))
                 .setInterventions(transform(dto.getInterventions(), InterventionTransformer::fromInterventionDTO_V1))
                 .setTriggers(


### PR DESCRIPTION
#267: The `importObservation` and `importIntervention` MUST use the parsed `studyId` - representing the study id of the target system - when setting `observationGroupIds` for imported observations and interventions.

This fixes Exceptions such as 

```
org.postgresql.util.PSQLException: ERROR: insert or update on table \"observation_observation_groups\" violates foreign key constraint \"observation_observation_groups_study_id_fkey\"
  Detail: Key (study_id)=(41) is not present in table \"studies\".
    at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2734)
    at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2421)
    at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:372)
    at org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:518)
    at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:435)
    at org.postgresql.jdbc.PgPreparedStatement.executeWithFlags(PgPreparedStatement.java:196)
    at org.postgresql.jdbc.PgPreparedStatement.executeUpdate(PgPreparedStatement.java:157)
    at com.zaxxer.hikari.pool.ProxyPreparedStatement.executeUpdate(ProxyPreparedStatement.java:61)
    at com.zaxxer.hikari.pool.HikariProxyPreparedStatement.executeUpdate(HikariProxyPreparedStatement.java)
    at org.springframework.jdbc.core.JdbcTemplate.lambda$update$2(JdbcTemplate.java:977)
    at org.springframework.jdbc.core.JdbcTemplate.execute(JdbcTemplate.java:658)

```