### PR TITLE
This changes the initialization for the data health for new participa…

### DIFF
--- a/studymanager-services/src/main/java/io/redlink/more/studymanager/scheduling/UpsertOccurredObservationsCron.java
+++ b/studymanager-services/src/main/java/io/redlink/more/studymanager/scheduling/UpsertOccurredObservationsCron.java
@@ -62,16 +62,17 @@ public class UpsertOccurredObservationsCron {
             }
             ctx.putStudy(study);
             List<Participant> participants = participantService.listParticipants(study.getStudyId());
-            Instant lastOccurredObservation = occurredObservationService.getLatestStartTime(study.getStudyId());
             //NOTE: use now + 1min for current because:
             //  1. we truncatedTo(ChronoUnit.MINUTES) all Instants and
             //  2. we check with start.isBefore(current)
             // doing so will include all Observations that start in the current minute
             Instant current = Instant.now().plus(1, ChronoUnit.MINUTES).truncatedTo(ChronoUnit.MINUTES);
-            LOGGER.debug("Upsert Occurred Observations for Study(id: {}) and timeperiode(start:{}, end:{})", study.getStudyId(), lastOccurredObservation, current);
+            LOGGER.debug("Upsert Occurred Observations for Study(id: {}) ", study.getStudyId());
             participants.stream()
                 .filter(participant -> participant.getStatus() == Participant.Status.ACTIVE)
                 .forEach(participant -> {
+                    Instant lastOccurredObservation = occurredObservationService.getLatestStartTime(study.getStudyId(), participant.getParticipantId());
+                    LOGGER.debug("Upsert Occurred Observations for Study(id: {}) Participant(id: {}) and timeperiode(start:{}, end:{})", study.getStudyId(), participant.getParticipantId(), lastOccurredObservation, current);
                     ctx.putParticipant(participant);
                     //NOTE: from, to are currently not supported
                     var timeline = calendarService.getTimeline(study, participant, null, null, null, null, null);

--- a/studymanager-services/src/main/java/io/redlink/more/studymanager/service/OccurredObservationService.java
+++ b/studymanager-services/src/main/java/io/redlink/more/studymanager/service/OccurredObservationService.java
@@ -40,10 +40,11 @@ public class OccurredObservationService {
     /**
      * The latest start time of any {@link OccurredObservation} for the parst studyId
      * @param studyId the study id
+     * @param participantId the participantId
      * @return the latest start time or <code>null</code> if no {@link OccurredObservation} is present for the study
      */
-    public Instant getLatestStartTime(long studyId) {
-        return repository.getLatestStartTime(studyId, null, null, null, null);
+    public Instant getLatestStartTime(long studyId, int participantId) {
+        return repository.getLatestStartTime(studyId, participantId, null, null, null);
     }
 
     /**

--- a/studymanager-services/src/test/java/io/redlink/more/studymanager/scheduling/UpsertOccurredObservationsCronTest.java
+++ b/studymanager-services/src/test/java/io/redlink/more/studymanager/scheduling/UpsertOccurredObservationsCronTest.java
@@ -200,7 +200,7 @@ public class UpsertOccurredObservationsCronTest {
 
 
         //finally moch the two methods used in the occurredObservationService
-        when(occurredObservationService.getLatestStartTime(anyLong()))
+        when(occurredObservationService.getLatestStartTime(anyLong(), anyInt()))
                 .thenReturn(lastOoTimestamp);
 
         when(occurredObservationService.upsert(anyLong(), anyInt(), anyInt(), any(), any()))
@@ -219,9 +219,11 @@ public class UpsertOccurredObservationsCronTest {
 
         //verify the the #getLatestStartTime(..) method is called for each study once
         ArgumentCaptor<Long> studyIdCaptor = ArgumentCaptor.forClass(Long.class);
-        verify(occurredObservationService, times(2))
-                .getLatestStartTime(studyIdCaptor.capture());
+        ArgumentCaptor<Integer> participantIdCaptor = ArgumentCaptor.forClass(Integer.class);
+        verify(occurredObservationService, times(5))
+                .getLatestStartTime(studyIdCaptor.capture(), participantIdCaptor.capture());
         assertThat(studyIdCaptor.getAllValues()).contains(1L, 2L);
+        assertThat(participantIdCaptor.getAllValues()).contains(1,2,3,1,2);
 
         ArgumentCaptor<Long> ooStudyIdCaptor = ArgumentCaptor.forClass(Long.class);
         ArgumentCaptor<Integer> ooObservationIdCaptor = ArgumentCaptor.forClass(Integer.class);


### PR DESCRIPTION
Previously the last occurred observation was calculated over the whole study. If a participant joined an ongoing study only occurred observations starting after the last corn run where considered. Now the start time is calculated for every participant. So if a participant joined the study - and does not has any occurred observations - also ongoing observations that started in the past are considered.