### PR TITLE
Clean DataHealth after Preview & Refactoring on how to deal with SideEffencts on Study State changes

### DIFF
--- a/studymanager-services/src/main/java/io/redlink/more/studymanager/event/StudyParticipantClosedEvent.java
+++ b/studymanager-services/src/main/java/io/redlink/more/studymanager/event/StudyParticipantClosedEvent.java
@@ -1,0 +1,17 @@
+package io.redlink.more.studymanager.event;
+
+import io.redlink.more.studymanager.model.Participant;
+import org.springframework.context.ApplicationEvent;
+
+public class StudyParticipantClosedEvent extends ApplicationEvent {
+    private Participant participant;
+
+    public StudyParticipantClosedEvent(Object source, Participant participant) {
+        super(source);
+        this.participant = participant;
+    }
+
+    public Participant getParticipant() {
+        return participant;
+    }
+}

--- a/studymanager-services/src/main/java/io/redlink/more/studymanager/event/StudyStateChangedEvent.java
+++ b/studymanager-services/src/main/java/io/redlink/more/studymanager/event/StudyStateChangedEvent.java
@@ -1,0 +1,23 @@
+package io.redlink.more.studymanager.event;
+
+import io.redlink.more.studymanager.model.Study;
+import org.springframework.context.ApplicationEvent;
+
+public class StudyStateChangedEvent extends ApplicationEvent {
+    private Study study;
+    private Study.Status previousState;
+
+    public StudyStateChangedEvent(Object source, Study study, Study.Status previousState) {
+        super(source);
+        this.study = study;
+        this.previousState = previousState;
+    }
+
+    public Study getStudy() {
+        return study;
+    }
+
+    public Study.Status getPreviousState() {
+        return previousState;
+    }
+}

--- a/studymanager-services/src/main/java/io/redlink/more/studymanager/repository/OccurredObservationRepository.java
+++ b/studymanager-services/src/main/java/io/redlink/more/studymanager/repository/OccurredObservationRepository.java
@@ -69,6 +69,11 @@ public class OccurredObservationRepository {
                     LIMIT 1
             """;
 
+    private static String DELETE_BY_STUDY_ID = """
+            DELETE FROM occurred_observation oo
+            WHERE oo.study_id = :study_id
+    """;
+
     private static final String DELETE_ALL = "DELETE FROM occurred_observation";
     private final JdbcTemplate template;
     private final NamedParameterJdbcTemplate namedTemplate;
@@ -152,6 +157,12 @@ public class OccurredObservationRepository {
         }
     }
 
+    public void deleteOccurredObservations(Long studyId) {
+        namedTemplate.update(DELETE_ALL,
+                new MapSqlParameterSource("study_id", studyId));
+    }
+
+
     public void clear() {
         template.update(DELETE_ALL);
     }
@@ -203,4 +214,5 @@ public class OccurredObservationRepository {
         return (rs, rowNum) -> withTimezone ? RepositoryUtils.readInstantUTC(rs, field) :
                 RepositoryUtils.readInstant(rs, field);
     }
+
 }

--- a/studymanager-services/src/main/java/io/redlink/more/studymanager/scheduling/StudyParticipantCron.java
+++ b/studymanager-services/src/main/java/io/redlink/more/studymanager/scheduling/StudyParticipantCron.java
@@ -1,0 +1,50 @@
+package io.redlink.more.studymanager.scheduling;
+
+import io.redlink.more.studymanager.event.StudyParticipantClosedEvent;
+import io.redlink.more.studymanager.model.Participant;
+import io.redlink.more.studymanager.service.ParticipantService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class StudyParticipantCron {
+
+    private static final Logger log = LoggerFactory.getLogger(StudyParticipantCron.class);
+
+    private final ApplicationEventPublisher applicationEventPublisher;
+    private final ParticipantService participantService;
+
+    public StudyParticipantCron(ApplicationEventPublisher applicationEventPublisher, ParticipantService participantService) {
+        this.applicationEventPublisher = applicationEventPublisher;
+        this.participantService = participantService;
+    }
+
+    // every minute
+    @Scheduled(cron = "0 * * * * ?")
+    public void closeParticipationsForStudiesWithDurations() {
+        List<Participant> participantsToClose = participantService.listParticipantsForClosing();
+        log.debug("Selected {} participants to close", participantsToClose.size());
+        participantsToClose.forEach(participant -> {
+            log.debug("Close {} ", participant);
+            try {
+                publishStudyParticipantClosedEvent(participant);
+                participantService.setStatus(
+                        participant.getStudyId(), participant.getParticipantId(), Participant.Status.LOCKED
+                );
+            } catch (Exception ex) {
+                log.warn("Failed to close participant {} ({} - {})", participant, ex.getClass().getSimpleName(), ex.getMessage(), ex);
+            }
+        });
+    }
+
+    private void publishStudyParticipantClosedEvent(final Participant participant) {
+        applicationEventPublisher.publishEvent(new StudyParticipantClosedEvent(this, participant));
+    }
+
+
+}

--- a/studymanager-services/src/main/java/io/redlink/more/studymanager/service/IntegrationService.java
+++ b/studymanager-services/src/main/java/io/redlink/more/studymanager/service/IntegrationService.java
@@ -8,9 +8,11 @@
  */
 package io.redlink.more.studymanager.service;
 
+import io.redlink.more.studymanager.event.StudyStateChangedEvent;
 import io.redlink.more.studymanager.model.EndpointToken;
 import io.redlink.more.studymanager.model.Study;
 import io.redlink.more.studymanager.repository.IntegrationRepository;
+import org.springframework.context.event.EventListener;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -75,7 +77,12 @@ public class IntegrationService {
         return repository.updateToken(studyId, observationId, tokenId, tokenLabel);
     }
 
-    public void alignIntegrationsWithStudyState(Study study) {
+    @EventListener
+    public void handleStudyStateChange(StudyStateChangedEvent event) {
+        alignIntegrationsWithStudyState(event.getStudy());
+    }
+
+    protected void alignIntegrationsWithStudyState(Study study) {
         if(study.getStudyState() == Study.Status.CLOSED) {
             repository.clearForStudyId(study.getStudyId());
         }

--- a/studymanager-services/src/main/java/io/redlink/more/studymanager/service/IntegrationService.java
+++ b/studymanager-services/src/main/java/io/redlink/more/studymanager/service/IntegrationService.java
@@ -82,7 +82,7 @@ public class IntegrationService {
         alignIntegrationsWithStudyState(event.getStudy());
     }
 
-    protected void alignIntegrationsWithStudyState(Study study) {
+    private void alignIntegrationsWithStudyState(Study study) {
         if(study.getStudyState() == Study.Status.CLOSED) {
             repository.clearForStudyId(study.getStudyId());
         }

--- a/studymanager-services/src/main/java/io/redlink/more/studymanager/service/InterventionService.java
+++ b/studymanager-services/src/main/java/io/redlink/more/studymanager/service/InterventionService.java
@@ -8,6 +8,7 @@
  */
 package io.redlink.more.studymanager.service;
 
+import io.redlink.more.studymanager.event.StudyStateChangedEvent;
 import io.redlink.more.studymanager.core.component.Component;
 import io.redlink.more.studymanager.core.exception.ConfigurationValidationException;
 import io.redlink.more.studymanager.core.factory.ActionFactory;
@@ -152,7 +153,12 @@ public class InterventionService {
         });
     }
 
-    public void alignInterventionsWithStudyState(Study study) {
+    @EventListener
+    public void handleStudyStateChange(StudyStateChangedEvent event) {
+        alignInterventionsWithStudyState(event.getStudy());
+    }
+
+    protected void alignInterventionsWithStudyState(Study study) {
         if (Study.Status.ACTIVE_STATES.contains(study.getStudyState())) {
             activateInterventionsFor(study);
         } else {

--- a/studymanager-services/src/main/java/io/redlink/more/studymanager/service/InterventionService.java
+++ b/studymanager-services/src/main/java/io/redlink/more/studymanager/service/InterventionService.java
@@ -158,7 +158,7 @@ public class InterventionService {
         alignInterventionsWithStudyState(event.getStudy());
     }
 
-    protected void alignInterventionsWithStudyState(Study study) {
+    private void alignInterventionsWithStudyState(Study study) {
         if (Study.Status.ACTIVE_STATES.contains(study.getStudyState())) {
             activateInterventionsFor(study);
         } else {

--- a/studymanager-services/src/main/java/io/redlink/more/studymanager/service/ObservationService.java
+++ b/studymanager-services/src/main/java/io/redlink/more/studymanager/service/ObservationService.java
@@ -8,6 +8,7 @@
  */
 package io.redlink.more.studymanager.service;
 
+import io.redlink.more.studymanager.event.StudyStateChangedEvent;
 import io.redlink.more.studymanager.core.component.Component;
 import io.redlink.more.studymanager.core.exception.ConfigurationValidationException;
 import io.redlink.more.studymanager.core.factory.ObservationFactory;
@@ -24,6 +25,7 @@ import io.redlink.more.studymanager.model.Study;
 import io.redlink.more.studymanager.repository.ObservationRepository;
 import io.redlink.more.studymanager.sdk.MoreSDK;
 import io.redlink.more.studymanager.utils.RandomSchedulerUtils;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -94,7 +96,12 @@ public class ObservationService {
         return updatedObservation;
     }
 
-    public void alignObservationsWithStudyState(Study study) {
+    @EventListener
+    public void handleStudyStateChange(StudyStateChangedEvent event) {
+        alignObservationsWithStudyState(event.getStudy());
+    }
+
+    protected void alignObservationsWithStudyState(Study study) {
         if (Study.Status.ACTIVE_STATES.contains(study.getStudyState()))
             activateObservationsFor(study);
         else deactivateObservationsFor(study);

--- a/studymanager-services/src/main/java/io/redlink/more/studymanager/service/OccurredObservationService.java
+++ b/studymanager-services/src/main/java/io/redlink/more/studymanager/service/OccurredObservationService.java
@@ -107,4 +107,9 @@ public class OccurredObservationService {
                 observationDataStates == null ? EnumSet.allOf(ObservationDataState.class) : observationDataStates);
     }
 
+    public void deleteOccurredObservations(Long studyId) {
+        repository.deleteOccurredObservations(studyId);
+    }
+
+
 }

--- a/studymanager-services/src/main/java/io/redlink/more/studymanager/service/ParticipantNotificationWorker.java
+++ b/studymanager-services/src/main/java/io/redlink/more/studymanager/service/ParticipantNotificationWorker.java
@@ -1,0 +1,45 @@
+package io.redlink.more.studymanager.service;
+
+import io.redlink.more.studymanager.event.StudyParticipantClosedEvent;
+import io.redlink.more.studymanager.event.StudyStateChangedEvent;
+import io.redlink.more.studymanager.model.Study;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ParticipantNotificationWorker {
+
+    private static final Logger log = LoggerFactory.getLogger(ParticipantNotificationWorker.class);
+    private final ParticipantService participantService;
+    private final PushNotificationService pushNotificationService;
+
+    public ParticipantNotificationWorker(
+            ParticipantService participantService,
+            PushNotificationService pushNotificationService) {
+        this.participantService = participantService;
+        this.pushNotificationService = pushNotificationService;
+    }
+
+    @EventListener
+    public void handleStudyStateChanged(StudyStateChangedEvent event) {
+        log.info("Notifying participants of Study[id:{}] about state transition from {} to {}",
+                event.getStudy().getStudyId(), event.getPreviousState(), event.getStudy().getStudyState());
+        participantService.listParticipants(event.getStudy().getStudyId())
+            .forEach(participant ->
+                pushNotificationService.sendStudyStateUpdate(
+                    participant,
+                    event.getPreviousState(),
+                    event.getStudy().getStudyState()));
+    }
+
+    @EventListener
+    public void handleStudyParticipantClosed(StudyParticipantClosedEvent event) {
+        log.info("Notifying participant[study={}, id={}] about transition to closed state",
+                event.getParticipant().getStudyId(), event.getParticipant().getParticipantId());
+        pushNotificationService.sendStudyStateUpdate(
+                event.getParticipant(), Study.Status.ACTIVE, Study.Status.CLOSED
+        );
+    }
+}

--- a/studymanager-services/src/main/java/io/redlink/more/studymanager/service/ParticipantService.java
+++ b/studymanager-services/src/main/java/io/redlink/more/studymanager/service/ParticipantService.java
@@ -8,6 +8,7 @@
  */
 package io.redlink.more.studymanager.service;
 
+import io.redlink.more.studymanager.event.StudyStateChangedEvent;
 import io.redlink.more.studymanager.model.Participant;
 import io.redlink.more.studymanager.model.Study;
 import io.redlink.more.studymanager.model.generator.RandomTokenGenerator;
@@ -16,6 +17,7 @@ import io.redlink.more.studymanager.repository.ParticipantRepository;
 import java.util.EnumSet;
 import java.util.List;
 
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -64,8 +66,13 @@ public class ParticipantService {
         return participantRepository.update(participant);
     }
 
+    @EventListener
+    public void handleStudyStateChange(StudyStateChangedEvent event) {
+        alignParticipantsWithStudyState(event.getStudy());
+    }
+
     @Transactional
-    public void alignParticipantsWithStudyState(Study study) {
+    protected void alignParticipantsWithStudyState(Study study) {
         if (EnumSet.of(Study.Status.CLOSED).contains(study.getStudyState())) {
             participantRepository.cleanupParticipants(study.getStudyId());
         }

--- a/studymanager-services/src/main/java/io/redlink/more/studymanager/service/ParticipantService.java
+++ b/studymanager-services/src/main/java/io/redlink/more/studymanager/service/ParticipantService.java
@@ -67,12 +67,13 @@ public class ParticipantService {
     }
 
     @EventListener
+    @Transactional
     public void handleStudyStateChange(StudyStateChangedEvent event) {
         alignParticipantsWithStudyState(event.getStudy());
     }
 
-    @Transactional
-    protected void alignParticipantsWithStudyState(Study study) {
+
+    private void alignParticipantsWithStudyState(Study study) {
         if (EnumSet.of(Study.Status.CLOSED).contains(study.getStudyState())) {
             participantRepository.cleanupParticipants(study.getStudyId());
         }

--- a/studymanager-services/src/main/java/io/redlink/more/studymanager/service/StudyService.java
+++ b/studymanager-services/src/main/java/io/redlink/more/studymanager/service/StudyService.java
@@ -8,11 +8,11 @@
  */
 package io.redlink.more.studymanager.service;
 
+import io.redlink.more.studymanager.event.StudyStateChangedEvent;
 import io.redlink.more.studymanager.exception.BadRequestException;
 import io.redlink.more.studymanager.exception.DataConstraintException;
 import io.redlink.more.studymanager.exception.NotFoundException;
 import io.redlink.more.studymanager.model.MoreUser;
-import io.redlink.more.studymanager.model.Participant;
 import io.redlink.more.studymanager.model.Study;
 import io.redlink.more.studymanager.model.StudyGroup;
 import io.redlink.more.studymanager.model.StudyRole;
@@ -33,7 +33,7 @@ import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -53,31 +53,27 @@ public class StudyService {
     private final StudyRepository studyRepository;
     private final StudyAclRepository aclRepository;
     private final UserRepository userRepo;
-    private final InterventionService interventionService;
-    private final ObservationService observationService;
-    private final ParticipantService participantService;
     private final StudyStateService studyStateService;
-    private final IntegrationService integrationService;
     private final ElasticService elasticService;
+    private final OccurredObservationService occurredObservationService;
 
-    private final PushNotificationService pushNotificationService;
     private final StudyGroupRepository studyGroupRepository;
+
+    private ApplicationEventPublisher applicationEventPublisher;
 
 
     public StudyService(StudyRepository studyRepository, StudyAclRepository aclRepository, UserRepository userRepo,
-                        StudyStateService studyStateService, InterventionService interventionService, ObservationService observationService,
-                        ParticipantService participantService, IntegrationService integrationService, ElasticService elasticService, PushNotificationService pushNotificationService, StudyGroupRepository studyGroupRepository) {
+                        StudyStateService studyStateService, OccurredObservationService occurredObservationService,
+                        ElasticService elasticService, StudyGroupRepository studyGroupRepository,
+                        ApplicationEventPublisher applicationEventPublisher) {
         this.studyRepository = studyRepository;
         this.aclRepository = aclRepository;
         this.userRepo = userRepo;
         this.studyStateService = studyStateService;
-        this.interventionService = interventionService;
-        this.observationService = observationService;
-        this.participantService = participantService;
-        this.integrationService = integrationService;
         this.elasticService = elasticService;
-        this.pushNotificationService = pushNotificationService;
         this.studyGroupRepository = studyGroupRepository;
+        this.occurredObservationService = occurredObservationService;
+        this.applicationEventPublisher = applicationEventPublisher;
     }
 
     public Study createStudy(Study study, User currentUser) {
@@ -114,6 +110,7 @@ public class StudyService {
         studyStateService.assertStudyState(studyId, Study.Status.DRAFT, Study.Status.CLOSED);
         studyRepository.deleteById(studyId);
         elasticService.deleteIndex(studyId);
+        occurredObservationService.deleteOccurredObservations(studyId);
     }
 
     @Transactional
@@ -130,45 +127,23 @@ public class StudyService {
         return studyRepository.setStateById(studyId, newState)
                 .map(s -> {
                     try {
-                        alignWithStudyState(s);
-                        participantService.listParticipants(studyId).forEach(participant ->
-                                pushNotificationService.sendStudyStateUpdate(participant, oldState, s.getStudyState())
-                        );
-                        participantService.alignParticipantsWithStudyState(s);
+                        publishStudyStateChangedEvent(s, oldState);
                         if (s.getStudyState() == Study.Status.DRAFT) {
-                            log.info("Study {} transitioned back to {}, dropping collected observation data", study.getStudyId(), s.getStudyState());
+                            log.info("Study {} transitioned back to {}, dropping collected observation and data health information", study.getStudyId(), s.getStudyState());
                             elasticService.deleteIndex(s.getStudyId());
+                            occurredObservationService.deleteOccurredObservations(studyId);
                         }
                     } catch (Exception e) {
                         log.warn("Could not set new state for study id {}; old state: {}; new state: {}", studyId, oldState.getValue(), s.getStudyState().getValue());
                         //ROLLBACK
                         studyRepository.setStateById(studyId, oldState);
-                        studyRepository.getById(studyId).ifPresent(this::alignWithStudyState);
+                        studyRepository.getById(studyId).ifPresent(rollbackStudy -> {
+                            publishStudyStateChangedEvent(rollbackStudy, newState);
+                        });
                         throw new BadRequestException("Study cannot be initialized", e);
                     }
                     return s;
                 });
-    }
-
-    // every minute
-    @Scheduled(cron = "0 * * * * ?")
-    public void closeParticipationsForStudiesWithDurations() {
-        List<Participant> participantsToClose = participantService.listParticipantsForClosing();
-        log.debug("Selected {} participants to close", participantsToClose.size());
-        participantsToClose.forEach(participant -> {
-            pushNotificationService.sendStudyStateUpdate(
-                    participant, Study.Status.ACTIVE, Study.Status.CLOSED
-            );
-            participantService.setStatus(
-                    participant.getStudyId(), participant.getParticipantId(), Participant.Status.LOCKED
-            );
-        });
-    }
-
-    private void alignWithStudyState(Study s) {
-        interventionService.alignInterventionsWithStudyState(s);
-        observationService.alignObservationsWithStudyState(s);
-        integrationService.alignIntegrationsWithStudyState(s);
     }
 
     public Map<MoreUser, Set<StudyRole>> getACL(Long studyId) {
@@ -233,4 +208,7 @@ public class StudyService {
         return states == null ? Stream.empty() : studyRepository.listStudiesByStates(states);
     }
 
+    protected void publishStudyStateChangedEvent(final Study study, final Study.Status previousState) {
+        applicationEventPublisher.publishEvent(new StudyStateChangedEvent(this, study, previousState));
+    }
 }

--- a/studymanager-services/src/test/java/io/redlink/more/studymanager/repository/OccurredObservationRepositoryTest.java
+++ b/studymanager-services/src/test/java/io/redlink/more/studymanager/repository/OccurredObservationRepositoryTest.java
@@ -256,6 +256,10 @@ class OccurredObservationRepositoryTest {
         //validate that searching for a combination with no entry returns null
         var lastStartTimeNotFound = occurredObservationRepository.getLatestStartTime(studyId, -1, null, null, null);
         assertThat(lastStartTimeNotFound).isNull();
+
+        //Test deletion by studyId
+        occurredObservationRepository.deleteOccurredObservations(studyId);
+        assertThat(occurredObservationRepository.listOccurredObservations(studyId, null, null, null, null).toList()).isEmpty();
     }
 
 }

--- a/studymanager-services/src/test/java/io/redlink/more/studymanager/service/IntegrationServiceTest.java
+++ b/studymanager-services/src/test/java/io/redlink/more/studymanager/service/IntegrationServiceTest.java
@@ -9,20 +9,16 @@
 package io.redlink.more.studymanager.service;
 
 import io.redlink.more.studymanager.core.exception.ConfigurationValidationException;
+import io.redlink.more.studymanager.core.factory.TriggerFactory;
 import io.redlink.more.studymanager.core.validation.ConfigurationValidationReport;
 import io.redlink.more.studymanager.event.StudyStateChangedEvent;
 import io.redlink.more.studymanager.exception.BadRequestException;
 import io.redlink.more.studymanager.exception.NotFoundException;
-import io.redlink.more.studymanager.core.factory.TriggerFactory;
 import io.redlink.more.studymanager.model.AuthenticatedUser;
 import io.redlink.more.studymanager.model.PlatformRole;
 import io.redlink.more.studymanager.model.Study;
 import io.redlink.more.studymanager.model.Trigger;
-import java.util.EnumSet;
-import java.util.UUID;
-
-import io.redlink.more.studymanager.repository.InterventionRepository;
-import io.redlink.more.studymanager.repository.StudyRepository;
+import io.redlink.more.studymanager.repository.IntegrationRepository;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -30,8 +26,11 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
+import java.util.EnumSet;
 import java.util.Map;
+import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -40,42 +39,29 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-class InterventionServiceTest {
-    @Mock
-    Map<String, TriggerFactory> triggerFactories;
+class IntegrationServiceTest {
     @Mock
     StudyStateService studyStateService;
     @Mock
-    InterventionRepository repository;
+    IntegrationRepository repository;
     @Mock
-    StudyRepository studyRepository;
+    PasswordEncoder passwordEncoder;
     @InjectMocks
-    InterventionService interventionService;
-
-    private final AuthenticatedUser currentUser = new AuthenticatedUser(
-            UUID.randomUUID().toString(),
-            "Test User", "test@example.com", "Test Inc.",
-            EnumSet.allOf(PlatformRole.class)
-    );
+    IntegrationService integrationService;
 
     @Test
-    void testNotFoundValidation() {
-        NotFoundException notFoundException = Assertions.assertThrows(NotFoundException.class, () ->
-                interventionService.updateTrigger(1L, 1, new Trigger().setType("my-trigger"))
-        );
-        Assertions.assertEquals("Trigger Factory 'my-trigger' cannot be found", notFoundException.getMessage());
-    }
+    void testHandleStudyStateChange() {
+        Study study = new Study()
+                .setStudyId(1L)
+                .setTitle("Test study")
+                .setStudyState(Study.Status.ACTIVE);
 
-    @Test
-    void testBadRequestValidation() {
-        TriggerFactory factory = mock(TriggerFactory.class);
-        when(factory.validate(any())).thenThrow(new ConfigurationValidationException(ConfigurationValidationReport.init().error("My error")));
-        when(triggerFactories.get("my-trigger")).thenReturn(factory);
-        when(triggerFactories.containsKey("my-trigger")).thenReturn(true);
+        integrationService.handleStudyStateChange(new StudyStateChangedEvent(this,study, Study.Status.DRAFT ));
+        Mockito.verify(repository, Mockito.never()).clearForStudyId(anyLong());
+        study.setStudyState(Study.Status.CLOSED);
+        integrationService.handleStudyStateChange(new StudyStateChangedEvent(this,study, Study.Status.ACTIVE ));
+        Mockito.verify(repository, Mockito.times(1)).clearForStudyId(eq(study.getStudyId()));
 
-        Assertions.assertThrows(BadRequestException.class, () ->
-                interventionService.updateTrigger(1L, 1, new Trigger().setType("my-trigger"))
-        );
     }
 
 }

--- a/studymanager-services/src/test/java/io/redlink/more/studymanager/service/ParticipantServiceTest.java
+++ b/studymanager-services/src/test/java/io/redlink/more/studymanager/service/ParticipantServiceTest.java
@@ -8,7 +8,9 @@
  */
 package io.redlink.more.studymanager.service;
 
+import io.redlink.more.studymanager.event.StudyStateChangedEvent;
 import io.redlink.more.studymanager.model.Participant;
+import io.redlink.more.studymanager.model.Study;
 import io.redlink.more.studymanager.model.generator.RandomTokenGenerator;
 import io.redlink.more.studymanager.repository.ParticipantRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -16,10 +18,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -73,4 +78,32 @@ class ParticipantServiceTest {
         verify(elasticService, times(2)).removeDataForParticipant(any(), any());
 
     }
+
+    @Test
+    void testHandleStudyStateChange() {
+        Study study = new Study()
+                .setStudyId(1L)
+                .setTitle("Test study")
+                .setStudyState(Study.Status.ACTIVE);
+
+        participantService.handleStudyStateChange(new StudyStateChangedEvent(this,study, Study.Status.DRAFT ));
+        Mockito.verify(participantRepository, Mockito.never()).resetParticipants(anyLong(), any());
+        Mockito.verify(participantRepository, Mockito.never()).cleanupParticipants(anyLong());
+
+        //validate participants are reset if study goes to DRAFT state
+        study.setStudyState(Study.Status.DRAFT);
+        participantService.handleStudyStateChange(new StudyStateChangedEvent(this,study, Study.Status.PREVIEW ));
+        Mockito.verify(participantRepository, Mockito.times(1)).resetParticipants(eq(study.getStudyId()), any());
+        Mockito.verify(participantRepository, Mockito.never()).cleanupParticipants(anyLong());
+
+        Mockito.reset(participantRepository);
+
+        //validate participants are cleaned if study goes to CLOSED state
+        study.setStudyState(Study.Status.CLOSED);
+        participantService.handleStudyStateChange(new StudyStateChangedEvent(this,study, Study.Status.ACTIVE ));
+        Mockito.verify(participantRepository, Mockito.times(1)).cleanupParticipants(eq(study.getStudyId()));
+        Mockito.verify(participantRepository, Mockito.never()).resetParticipants(anyLong(), any());
+
+    }
+
 }

--- a/studymanager-services/src/test/java/io/redlink/more/studymanager/service/StudyServiceTest.java
+++ b/studymanager-services/src/test/java/io/redlink/more/studymanager/service/StudyServiceTest.java
@@ -8,6 +8,7 @@
  */
 package io.redlink.more.studymanager.service;
 
+import io.redlink.more.studymanager.event.StudyStateChangedEvent;
 import io.redlink.more.studymanager.exception.BadRequestException;
 import io.redlink.more.studymanager.model.AuthenticatedUser;
 import io.redlink.more.studymanager.model.Contact;
@@ -30,15 +31,19 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -51,19 +56,7 @@ class StudyServiceTest {
     StudyRepository studyRepository;
 
     @Mock
-    ParticipantService participantService;
-
-    @Mock
-    ObservationService observationService;
-
-    @Mock
-    InterventionService interventionService;
-
-    @Mock
-    IntegrationService integrationService;
-
-    @Mock
-    PushNotificationService pushNotificationService;
+    OccurredObservationService occurredObservationService;
 
     @Mock
     ElasticService elasticService;
@@ -76,6 +69,9 @@ class StudyServiceTest {
 
     @Mock
     StudyStateService studyStateService;
+
+    @Mock
+    ApplicationEventPublisher applicationEventPublisher;
 
     @InjectMocks
     StudyService studyService;
@@ -168,7 +164,8 @@ class StudyServiceTest {
         );
 
         when(studyRepository.getById(eq(study.getStudyId()), any())).thenReturn(Optional.of(study));
-        when(participantService.listParticipants(study.getStudyId())).thenReturn(pt);
+
+        doNothing().when(applicationEventPublisher).publishEvent(any(StudyStateChangedEvent.class));
         when(studyRepository.setStateById(eq(study.getStudyId()), any()))
                 .thenAnswer(i -> Optional.of(study.setStudyState(i.getArgument(1))));
 
@@ -176,27 +173,18 @@ class StudyServiceTest {
             tos.forEach(to -> {
                 study.setStudyState(from);
                 clearInvocations(
-                        observationService, interventionService, integrationService,
-                        participantService, pushNotificationService, elasticService
+                        occurredObservationService, elasticService, applicationEventPublisher
                 );
 
                 studyService.setStatus(1L, to, currentUser);
 
-                verify(observationService,
+                ArgumentCaptor<StudyStateChangedEvent> eventCaptor = ArgumentCaptor.forClass(StudyStateChangedEvent.class);
+                verify(applicationEventPublisher,
                         times(1).description("%s -> %s should align observations".formatted(from, to))
-                ).alignObservationsWithStudyState(study);
-                verify(interventionService,
-                        times(1).description("%s -> %s should align interventions".formatted(from, to))
-                ).alignInterventionsWithStudyState(study);
-                verify(integrationService,
-                        times(1).description("%s -> %s should align integrations".formatted(from, to))
-                ).alignIntegrationsWithStudyState(study);
-                verify(participantService,
-                        times(1).description("%s -> %s should align participants".formatted(from, to))
-                ).alignParticipantsWithStudyState(study);
-                verify(pushNotificationService,
-                        times(pt.size()).description("%s -> %s should send %d notifications".formatted(from, to, pt.size()))
-                ).sendStudyStateUpdate(any(), any(), any());
+                ).publishEvent(eventCaptor.capture());
+                assertThat(eventCaptor.getValue().getStudy().getStudyId()).isEqualTo(study.getStudyId());
+                assertThat(eventCaptor.getValue().getStudy().getStudyState()).isEqualTo(to);
+                assertThat(eventCaptor.getValue().getPreviousState()).isEqualTo(from);
 
                 // ONLY when transitioning to back to DRAFT, clear the collected data in Elastic
                 if ((from == Study.Status.PREVIEW || from == Study.Status.PAUSED_PREVIEW)
@@ -204,16 +192,21 @@ class StudyServiceTest {
                     verify(elasticService,
                             times(1).description("%s -> %s should delete the elastic index".formatted(from, to))
                     ).deleteIndex(study.getStudyId());
+                    verify(occurredObservationService,
+                            times(1).description("%s -> %s should delete the elastic index".formatted(from, to))
+                    ).deleteOccurredObservations(study.getStudyId());
                 } else {
                     verify(elasticService,
                             never().description("%s -> %s must not delete the elastic index".formatted(from, to))
                     ).deleteIndex(study.getStudyId());
+                    verify(occurredObservationService,
+                            never().description("%s -> %s must not delete the elastic index".formatted(from, to))
+                    ).deleteOccurredObservations(study.getStudyId());
                 }
             });
 
             clearInvocations(
-                    observationService, interventionService, integrationService,
-                    participantService, pushNotificationService, elasticService
+                    occurredObservationService, elasticService, applicationEventPublisher
             );
             EnumSet.complementOf(EnumSet.copyOf(tos)).forEach(invalidTo -> {
                 study.setStudyState(from);
@@ -221,8 +214,7 @@ class StudyServiceTest {
                         () -> studyService.setStatus(1L, invalidTo, currentUser),
                         () -> "Invalid Transition: %s -> %s".formatted(from, invalidTo));
                 Mockito.verifyNoInteractions(
-                        observationService, interventionService, integrationService,
-                        participantService, pushNotificationService, elasticService
+                        occurredObservationService, elasticService, applicationEventPublisher
                 );
             });
 


### PR DESCRIPTION
Feature:
    * This adds support for deleting Data Health information in case a study is set back to DRAFT after data where collected during the PREVIEW state

Refactoring:

    * StudyService does no longer implement all side effects when the study state is changed. It creates `StudyStateChangedEvent` and publishes them as Spring `ApplicationEvent`
    * All affected Services now provide `@EventListener` that perform any necessary side effects. This includes the `IntegrationService`, `InterventionService` and `ObservationService`
    * NOTE: The deletion of data in the ElasticIndex and data health data in the OccurredObservationRepository when a Study is transitioned from the PREVIEW to the DRAFT state is still done in the StudyService
    * Adapted the UnitTest to validate that the events are triggered