### PR TITLE
#303: Make ObservationFactory lookup dynamic

### DIFF
--- a/studymanager-core/src/main/java/io/redlink/more/studymanager/core/properties/model/Value.java
+++ b/studymanager-core/src/main/java/io/redlink/more/studymanager/core/properties/model/Value.java
@@ -126,4 +126,14 @@ public abstract class Value<T> {
         this.validationFunction = validationFunction;
         return this;
     }
+
+    @Override
+    public String toString() {
+        return "Value{" +
+                "id='" + id + '\'' +
+                ", defaultValue=" + defaultValue +
+                ", required=" + required +
+                ", immutable=" + immutable +
+                '}';
+    }
 }

--- a/studymanager-services/src/main/java/io/redlink/more/studymanager/configuration/ComponentFactoriesConfiguration.java
+++ b/studymanager-services/src/main/java/io/redlink/more/studymanager/configuration/ComponentFactoriesConfiguration.java
@@ -13,6 +13,8 @@ import io.redlink.more.studymanager.core.factory.ObservationFactory;
 import io.redlink.more.studymanager.core.factory.TriggerFactory;
 import io.redlink.more.studymanager.properties.ComponentFactoriesProperties;
 import org.reflections.Reflections;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
@@ -29,6 +31,7 @@ import java.util.stream.Collectors;
 @Configuration
 @EnableConfigurationProperties({ComponentFactoriesProperties.class})
 public class ComponentFactoriesConfiguration implements BeanFactoryAware {
+    private final Logger logger = LoggerFactory.getLogger(ComponentFactoriesConfiguration.class);
     private BeanFactory beanFactory;
 
     private final Reflections reflections;
@@ -61,8 +64,10 @@ public class ComponentFactoriesConfiguration implements BeanFactoryAware {
         Set<Class<? extends ObservationFactory>> observationFactories = reflections.getSubTypesOf(ObservationFactory.class);
         observationFactories.stream().map(this::instantiate)
                 .map(f -> f.init(componentFactoriesProperties.get(f.getId())))
-                .forEach(m ->
-                configurableBeanFactory.registerSingleton(m.getId(), m)
+                .forEach(m -> {
+                    logger.trace("Registering observation factory: {}[class:{}, properties:{}]", m.getId(),m.getClass().getName(), m.getProperties());
+                    configurableBeanFactory.registerSingleton(m.getId(), m);
+                }
         );
 
         /*

--- a/studymanager-services/src/main/java/io/redlink/more/studymanager/service/ObservationService.java
+++ b/studymanager-services/src/main/java/io/redlink/more/studymanager/service/ObservationService.java
@@ -56,7 +56,6 @@ public class ObservationService {
                               ApplicationContext applicationContext) {
         this.studyStateService = studyStateService;
         this.repository = repository;
-        //this.observationFactories = observationFactories;
         this.sdk = sdk;
         this.applicationContext = applicationContext;
     }

--- a/studymanager-services/src/main/java/io/redlink/more/studymanager/service/ObservationService.java
+++ b/studymanager-services/src/main/java/io/redlink/more/studymanager/service/ObservationService.java
@@ -25,9 +25,14 @@ import io.redlink.more.studymanager.model.Study;
 import io.redlink.more.studymanager.repository.ObservationRepository;
 import io.redlink.more.studymanager.sdk.MoreSDK;
 import io.redlink.more.studymanager.utils.RandomSchedulerUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Lookup;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
 
+import javax.annotation.Resource;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -37,20 +42,23 @@ import java.util.Optional;
 @Service
 public class ObservationService {
 
+    private final Logger log = LoggerFactory.getLogger(this.getClass());
+
     private final StudyStateService studyStateService;
     private final ObservationRepository repository;
 
-    private final Map<String, ObservationFactory> observationFactories;
     private final MoreSDK sdk;
+    ApplicationContext applicationContext;
 
     public ObservationService(StudyStateService studyStateService,
                               ObservationRepository repository,
-                              Map<String, ObservationFactory> observationFactories,
-                              MoreSDK sdk) {
+                              MoreSDK sdk,
+                              ApplicationContext applicationContext) {
         this.studyStateService = studyStateService;
         this.repository = repository;
-        this.observationFactories = observationFactories;
+        //this.observationFactories = observationFactories;
         this.sdk = sdk;
+        this.applicationContext = applicationContext;
     }
 
     public Observation addObservation(Observation observation) {
@@ -171,13 +179,15 @@ public class ObservationService {
     }
 
     private ObservationFactory factory(Observation observation) {
-        return observationFactories.get(observation.getType());
+        ObservationFactory factory = applicationContext.getBean(observation.getType(), ObservationFactory.class);
+        if(factory == null) {
+            throw NotFoundException.ObservationFactory(observation.getType());
+        } else {
+            return factory;
+        }
     }
 
     private Observation validate(Observation observation) {
-        if (!observationFactories.containsKey(observation.getType())) {
-            throw NotFoundException.ObservationFactory(observation.getType());
-        }
         try {
             final var factory = factory(observation);
             factory.validate(observation.getProperties());

--- a/studymanager-services/src/main/java/io/redlink/more/studymanager/service/ObservationService.java
+++ b/studymanager-services/src/main/java/io/redlink/more/studymanager/service/ObservationService.java
@@ -131,7 +131,6 @@ public class ObservationService {
                 for (ValidationIssue issue : e.getReport().getIssues()) {
                     issue.setComponentTitle(observation.getTitle());
                 }
-
                 throw e;
             }
         }
@@ -144,11 +143,9 @@ public class ObservationService {
         validateProperties(observations);
 
         for (Observation observation : observations) {
-            result.add(factory(observation)
-                    .create(
-                            sdk.scopedObservationSDK(observation.getStudyId(), observation.getStudyGroupId(), observation.getObservationId()),
-                            observation.getProperties()
-                    ));
+            result.add(factory(observation).create(
+                sdk.scopedObservationSDK(observation.getStudyId(), observation.getStudyGroupId(), observation.getObservationId()),
+                observation.getProperties()));
         }
 
         return result;
@@ -170,27 +167,29 @@ public class ObservationService {
         ).getView(viewName, studyGroupId, participantId, timerange);
     }
 
-    public Optional<ObservationFactory> getObservationFactory(Observation observation) {
-        return Optional.ofNullable(factory(observation));
-    }
-
     public List<ParticipantWithObservationProperties> getParticipantObservationProperties(Long studyId) {
         return repository.getParticipantObservationProperties(studyId);
     }
 
+    public Optional<ObservationFactory> getObservationFactory(Observation observation) {
+        return Optional.ofNullable(applicationContext.getBean(observation.getType(), ObservationFactory.class));
+    }
+
+    /**
+     * Ensures the observationFactory for the parsed Observation
+     * @param observation
+     * @return the factory
+     * @throws NotFoundException if the {@link ObservationFactory} for the parsed observation is not present
+     */
     private ObservationFactory factory(Observation observation) {
-        ObservationFactory factory = applicationContext.getBean(observation.getType(), ObservationFactory.class);
-        if(factory == null) {
-            throw NotFoundException.ObservationFactory(observation.getType());
-        } else {
-            return factory;
-        }
+        return getObservationFactory(observation)
+                .orElseThrow(() -> new NotFoundException(String.format("ObservationFactory for Observation[study: %s, id:%s, type: %s]",
+                        observation.getStudyId(), observation.getObservationId(), observation.getType())));
     }
 
     private Observation validate(Observation observation) {
         try {
-            final var factory = factory(observation);
-            factory.validate(observation.getProperties());
+            factory(observation).validate(observation.getProperties());
         } catch (ConfigurationValidationException e) {
             throw new BadRequestException(e.getMessage());
         }

--- a/studymanager-services/src/test/java/io/redlink/more/studymanager/service/ObservationServiceTest.java
+++ b/studymanager-services/src/test/java/io/redlink/more/studymanager/service/ObservationServiceTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationContext;
 
 import java.util.Map;
 
@@ -45,9 +46,6 @@ import static org.mockito.Mockito.when;
 class ObservationServiceTest {
 
     @Mock
-    Map<String, ObservationFactory> observationFactories;
-
-    @Mock
     StudyStateService studyStateService;
 
     @Mock
@@ -55,6 +53,9 @@ class ObservationServiceTest {
 
     @Mock
     MoreSDK sdk;
+
+    @Mock
+    ApplicationContext applicationContext;
 
     @InjectMocks
     ObservationService observationService;
@@ -64,12 +65,11 @@ class ObservationServiceTest {
         NotFoundException notFoundException = Assertions.assertThrows(NotFoundException.class, () ->
                 observationService.addObservation(new Observation().setStudyId(1L).setObservationId(1).setType("my-observation"))
         );
-        Assertions.assertEquals("Observation Factory 'my-observation' cannot be found", notFoundException.getMessage());
+        Assertions.assertEquals("ObservationFactory for Observation[study: 1, id:1, type: my-observation] cannot be found", notFoundException.getMessage());
 
         ObservationFactory factory = mock(ObservationFactory.class);
         when(factory.validate(any())).thenThrow(new ConfigurationValidationException(ConfigurationValidationReport.init().error("My error")));
-        when(observationFactories.get("my-observation")).thenReturn(factory);
-        when(observationFactories.containsKey("my-observation")).thenReturn(true);
+        when(applicationContext.getBean("my-observation", ObservationFactory.class)).thenReturn(factory);
 
         BadRequestException badRequestException = Assertions.assertThrows(BadRequestException.class, () ->
                 observationService.addObservation(new Observation().setStudyId(1L).setObservationId(1).setType("my-observation"))
@@ -142,12 +142,12 @@ class ObservationServiceTest {
     void testGetObservationFactory_optional() {
         Observation obs = new Observation().setType("x");
         ObservationFactory factory = org.mockito.Mockito.mock(ObservationFactory.class);
-        org.mockito.Mockito.when(observationFactories.get("x")).thenReturn(factory);
+        org.mockito.Mockito.when(applicationContext.getBean("x", ObservationFactory.class)).thenReturn(factory);
 
         java.util.Optional<ObservationFactory> present = observationService.getObservationFactory(obs);
         org.assertj.core.api.Assertions.assertThat(present).containsSame(factory);
 
-        org.mockito.Mockito.when(observationFactories.get("x")).thenReturn(null);
+        org.mockito.Mockito.when(applicationContext.getBean("x", ObservationFactory.class)).thenReturn(null);
         java.util.Optional<ObservationFactory> empty = observationService.getObservationFactory(obs);
         org.assertj.core.api.Assertions.assertThat(empty).isEmpty();
     }
@@ -176,14 +176,14 @@ class ObservationServiceTest {
         org.mockito.Mockito.when(component.listViews()).thenReturn(infos);
 
         ObservationFactory factory = org.mockito.Mockito.mock(ObservationFactory.class);
-        org.mockito.Mockito.when(observationFactories.get("t")).thenReturn(factory);
+        org.mockito.Mockito.when(applicationContext.getBean("t", ObservationFactory.class)).thenReturn(factory);
         org.mockito.Mockito.when(factory.create(org.mockito.Mockito.any(), org.mockito.Mockito.any())).thenReturn(component);
 
 
         io.redlink.more.studymanager.core.ui.DataViewInfo[] result = observationService.listDataViews(10L, 30);
         org.assertj.core.api.Assertions.assertThat(result).isSameAs(infos);
 
-        org.mockito.Mockito.verify(observationFactories).get("t");
+        org.mockito.Mockito.verify(applicationContext).getBean("t", ObservationFactory.class);
         org.mockito.Mockito.verify(factory).create(org.mockito.Mockito.any(), org.mockito.Mockito.any());
         org.mockito.Mockito.verify(component).listViews();
     }
@@ -198,14 +198,15 @@ class ObservationServiceTest {
         org.mockito.Mockito.when(component.getView(org.mockito.Mockito.eq("v2"), org.mockito.Mockito.eq(21), org.mockito.Mockito.eq(1), org.mockito.Mockito.any())).thenReturn(dataView);
 
         ObservationFactory factory = org.mockito.Mockito.mock(ObservationFactory.class);
-        org.mockito.Mockito.when(observationFactories.get("t2")).thenReturn(factory);
+        org.mockito.Mockito.when(applicationContext.getBean("t2", ObservationFactory.class)).thenReturn(factory);
+
         org.mockito.Mockito.when(factory.create(org.mockito.Mockito.any(), org.mockito.Mockito.any())).thenReturn(component);
 
 
         io.redlink.more.studymanager.core.ui.DataView result = observationService.queryData(10L, 31, "v2", 21, 1, null);
         org.assertj.core.api.Assertions.assertThat(result).isSameAs(dataView);
 
-        org.mockito.Mockito.verify(observationFactories).get("t2");
+        org.mockito.Mockito.verify(applicationContext).getBean("t2", ObservationFactory.class);
         org.mockito.Mockito.verify(factory).create(org.mockito.Mockito.any(), org.mockito.Mockito.any());
         org.mockito.Mockito.verify(component).getView(org.mockito.Mockito.eq("v2"), org.mockito.Mockito.eq(21), org.mockito.Mockito.eq(1), org.mockito.Mockito.any());
     }


### PR DESCRIPTION
#UMM/303 This changes the lookup for ObservationFactory beans to be dynamic. The ApplicationContext is now used to lookup beans by id (`obervergation.getType()`) at the time of request. The bug was caused by a change in the bean initialization caused by removing some dependencies from the StudyService. Wit this change the initialisation order has no effect.