### PR TITLE
#346: GoalTemplate Properties refinements

### DIFF
--- a/studymanager-core/src/main/java/io/redlink/more/studymanager/core/properties/model/ConfigSection.java
+++ b/studymanager-core/src/main/java/io/redlink/more/studymanager/core/properties/model/ConfigSection.java
@@ -8,6 +8,21 @@
  */
 package io.redlink.more.studymanager.core.properties.model;
 
+/**
+ * A ConfigSection is a marker property that allows to goup different parts of the
+ * configuration.
+ *
+ * It defines a title and an optional description and visually group all Values until the
+ * next ConfigSection in the configuration dialog. It does not contribute to the
+ * configuration.
+ *
+ * The ConfigSection property is always:
+ * <ul>
+ *     <li>{@link Value#isImmutable()} == true</li>
+ *     <li>{@link Value#getDefaultValue()} == null</li>
+ *     <li>{@link Value#isRequired()} == false</li>
+ * </ul>
+ */
 public class ConfigSection extends Value<Void> {
     public ConfigSection(String id) {
         super(id);
@@ -21,5 +36,20 @@ public class ConfigSection extends Value<Void> {
     @Override
     public String getType() {
         return "GROUPING";
+    }
+
+    @Override
+    public final boolean isImmutable() {
+        return true;
+    }
+
+    @Override
+    public final Void getDefaultValue() {
+        return null;
+    }
+
+    @Override
+    public final boolean isRequired() {
+        return false;
     }
 }

--- a/studymanager-core/src/main/java/io/redlink/more/studymanager/core/properties/model/Value.java
+++ b/studymanager-core/src/main/java/io/redlink/more/studymanager/core/properties/model/Value.java
@@ -15,6 +15,7 @@ import io.redlink.more.studymanager.core.exception.ValueNonNullException;
 import io.redlink.more.studymanager.core.properties.ComponentProperties;
 import io.redlink.more.studymanager.core.validation.ValidationIssue;
 
+import java.util.Objects;
 import java.util.function.Function;
 
 public abstract class Value<T> {
@@ -35,6 +36,12 @@ public abstract class Value<T> {
         if (required) {
             if (t == null) {
                 return ValidationIssue.requiredMissing(this);
+            }
+        }
+
+        if(immutable) {
+            if(!Objects.equals(defaultValue, t)){
+                return ValidationIssue.immutablePropertyChanged(this);
             }
         }
 

--- a/studymanager-core/src/main/java/io/redlink/more/studymanager/core/properties/model/ValueGroup.java
+++ b/studymanager-core/src/main/java/io/redlink/more/studymanager/core/properties/model/ValueGroup.java
@@ -8,6 +8,28 @@
  */
 package io.redlink.more.studymanager.core.properties.model;
 
+/**
+ * Marker for a Value group consisting out of all Values where the ID
+ * starts with '<code>${valuegroup.id}.</code>`.
+ *
+ * Example:
+ * <code>
+ *     Value&lt;Void&gt; group = new ValueGroup("group");
+ *     Value&lt;Integer&gt; value = new InteverValue(group.getId() + ".value");
+ *     Value&lt;String&gt; unit = new StringValue(group.getId() + ".unit");
+ * </code>
+ *
+ * This will place the value and unit into the same row ordered from left to right
+ * based on the order of the values in the property list. It does not contribute to the
+ * configuration.
+ *
+ * The ValueGroup property is always:
+ * <ul>
+ *     <li>{@link Value#isImmutable()} == true</li>
+ *     <li>{@link Value#getDefaultValue()} == null</li>
+ *     <li>{@link Value#isRequired()} == false</li>
+ * </ul>
+ */
 public class ValueGroup extends Value<Void> {
     public ValueGroup(String id) {
         super(id);
@@ -22,4 +44,21 @@ public class ValueGroup extends Value<Void> {
     public String getType() {
         return "GROUPING";
     }
+
+
+    @Override
+    public final boolean isImmutable() {
+        return true;
+    }
+
+    @Override
+    public final Void getDefaultValue() {
+        return null;
+    }
+
+    @Override
+    public final boolean isRequired() {
+        return false;
+    }
+
 }

--- a/studymanager-goaltemplates/src/main/java/io/redlink/more/studymanager/component/goaltemplate/AbstractAmountOfGoalTemplateFactory.java
+++ b/studymanager-goaltemplates/src/main/java/io/redlink/more/studymanager/component/goaltemplate/AbstractAmountOfGoalTemplateFactory.java
@@ -35,32 +35,27 @@ public abstract class AbstractAmountOfGoalTemplateFactory<C extends GoalTemplate
 
     protected static final Value<Void> CONFIG_SECTION_CONFIGURATION = new ConfigSection("configuration")
             .setName(AMOUNT_OF_PROPERTY_PREFIX + "section.configuration.name")
-            .setDescription(AMOUNT_OF_PROPERTY_PREFIX + "section.configuration.description")
-            .setImmutable(true);
+            .setDescription(AMOUNT_OF_PROPERTY_PREFIX + "section.configuration.description");
     protected static final Value<Void> CONFIG_SECTION_GOAL_CONFIGURATION = new ConfigSection("goal-configuration")
             .setName(AMOUNT_OF_PROPERTY_PREFIX + "section.goal.name")
-            .setDescription(AMOUNT_OF_PROPERTY_PREFIX + "section.goal.description")
-            .setImmutable(true);
+            .setDescription(AMOUNT_OF_PROPERTY_PREFIX + "section.goal.description");
     protected static final Value<Void> CONFIG_SECTION_STATUS = new ConfigSection("status-texts")
             .setName(AMOUNT_OF_PROPERTY_PREFIX + "section.status-texts.name")
-            .setDescription(AMOUNT_OF_PROPERTY_PREFIX + "section.status-texts.description")
-            .setImmutable(true);
+            .setDescription(AMOUNT_OF_PROPERTY_PREFIX + "section.status-texts.description");
     protected static final Value<Void> CONFIG_SECTION_SELF_REPORT = new ConfigSection("self-report")
             .setName(AMOUNT_OF_PROPERTY_PREFIX + "section.self-report.name")
-            .setDescription(AMOUNT_OF_PROPERTY_PREFIX + "section.self-report.description")
-            .setImmutable(true);
+            .setDescription(AMOUNT_OF_PROPERTY_PREFIX + "section.self-report.description");
 
     protected static final Value<Void> CONFIGS_GOAL_AMOUNT_GROUP = new ValueGroup("goal")
             .setName(AMOUNT_OF_PROPERTY_PREFIX + "goal.name")
-            .setDescription(AMOUNT_OF_PROPERTY_PREFIX + "goal.description")
-            .setImmutable(true);
-    protected static final Value<IntegerRange> CONFIGS_GOAL_AMOUNT_VALUE = new IntegerRangeValue("goal.amount")
+            .setDescription(AMOUNT_OF_PROPERTY_PREFIX + "goal.description");
+    protected static final Value<IntegerRange> CONFIGS_GOAL_AMOUNT_VALUE = new IntegerRangeValue(CONFIGS_GOAL_AMOUNT_GROUP.getId() + ".amount")
             .setMin(1)
             .setMax(Integer.MAX_VALUE)
             .setName(AMOUNT_OF_PROPERTY_PREFIX + "goal.amount.name")
             .setDescription(AMOUNT_OF_PROPERTY_PREFIX + "goal.amount.description")
             .setRequired(true);
-    protected static final Value<String> CONFIGS_GOAL_AMOUNT_UNIT = new StringValue("goal.unit")
+    protected static final Value<String> CONFIGS_GOAL_AMOUNT_UNIT = new StringValue(CONFIGS_GOAL_AMOUNT_GROUP.getId() + ".unit")
             .setName(AMOUNT_OF_PROPERTY_PREFIX + "goal.unit.name")
             .setDescription(AMOUNT_OF_PROPERTY_PREFIX + "goal.unit.description")
             .setRequired(true);

--- a/studymanager-goaltemplates/src/main/java/io/redlink/more/studymanager/component/goaltemplate/EatAmountOfGoalTemplateFactory.java
+++ b/studymanager-goaltemplates/src/main/java/io/redlink/more/studymanager/component/goaltemplate/EatAmountOfGoalTemplateFactory.java
@@ -41,7 +41,7 @@ public class EatAmountOfGoalTemplateFactory extends AbstractAmountOfGoalTemplate
                     .setName(AMOUNT_OF_PROPERTY_PREFIX + "goal-preview.name")
                     .setDescription(AMOUNT_OF_PROPERTY_PREFIX + "goal-preview.description")
                     .setDefaultValue("Ich esse mindestens <goal.amount> Portionen <goal.unit> [an <days-of-week> Tagen der Woche]")
-                    .setImmutable(true),
+                    .setImmutable(false),
                 AbstractAmountOfGoalTemplateFactory.CONFIGS_GOAL_AMOUNT_GROUP,
                 AbstractAmountOfGoalTemplateFactory.CONFIGS_GOAL_AMOUNT_VALUE,
                 AbstractAmountOfGoalTemplateFactory.CONFIGS_GOAL_AMOUNT_UNIT,
@@ -65,8 +65,7 @@ public class EatAmountOfGoalTemplateFactory extends AbstractAmountOfGoalTemplate
                 new StringTextValue("self-report-question")
                         .setName(AMOUNT_OF_PROPERTY_PREFIX + "self-report-question.name")
                         .setDescription(AMOUNT_OF_PROPERTY_PREFIX + "self-report-question.description")
-                        .setDefaultValue("Wie viele Portionen hast Du heute gegessen? Bitte trage den Wert ein."),
-                GoalTemplateFactory.SELF_REPORT_TIME_EVENING
+                        .setDefaultValue("Wie viele Portionen hast Du heute gegessen? Bitte trage den Wert ein.")
         );
     }
 

--- a/studymanager-goaltemplates/src/main/java/io/redlink/more/studymanager/component/goaltemplate/ReduceAmountOfGoalTemplateFactory.java
+++ b/studymanager-goaltemplates/src/main/java/io/redlink/more/studymanager/component/goaltemplate/ReduceAmountOfGoalTemplateFactory.java
@@ -38,7 +38,7 @@ public class ReduceAmountOfGoalTemplateFactory extends AbstractAmountOfGoalTempl
                         .setName(AMOUNT_OF_PROPERTY_PREFIX + "goal-preview.name")
                         .setDescription(AMOUNT_OF_PROPERTY_PREFIX + "goal-preview.description")
                         .setDefaultValue("Ich <goal.activity> maximal <goal.amount> <goal.unit> [an maximal <days-of-week> Tagen in der Woche]")
-                        .setImmutable(true),
+                        .setImmutable(false),
                 AbstractAmountOfGoalTemplateFactory.CONFIGS_GOAL_AMOUNT_GROUP,
                 new StringValue("goal.activity")
                         .setName(GOAL_TEMPLATE_PROPERTY_PREFIX + "reduceAmountOf.goal.activity.name")
@@ -67,8 +67,7 @@ public class ReduceAmountOfGoalTemplateFactory extends AbstractAmountOfGoalTempl
                 new StringTextValue("self-report-question")
                         .setName(AMOUNT_OF_PROPERTY_PREFIX + "self-report-question.name")
                         .setDescription(AMOUNT_OF_PROPERTY_PREFIX + "self-report-question.description")
-                        .setDefaultValue("Wie viele Einheiten hast Du heute <goal.activity>? Bitte trage den Wert ein."),
-                GoalTemplateFactory.SELF_REPORT_TIME_EVENING
+                        .setDefaultValue("Wie viele Einheiten hast Du heute <goal.activity>? Bitte trage den Wert ein.")
         );
     }
 

--- a/studymanager-goaltemplates/src/main/java/io/redlink/more/studymanager/component/goaltemplate/TrinkAmountOfGoalTemplateFactory.java
+++ b/studymanager-goaltemplates/src/main/java/io/redlink/more/studymanager/component/goaltemplate/TrinkAmountOfGoalTemplateFactory.java
@@ -37,7 +37,7 @@ public class TrinkAmountOfGoalTemplateFactory extends AbstractAmountOfGoalTempla
                         .setName(AMOUNT_OF_PROPERTY_PREFIX + "goal-preview.name")
                         .setDescription(AMOUNT_OF_PROPERTY_PREFIX + "goal-preview.description")
                         .setDefaultValue("Ich trinke mindestens <goal.amount> <goal.unit> [an <days-of-week> Tagen der Woche]")
-                        .setImmutable(true),
+                        .setImmutable(false),
                 AbstractAmountOfGoalTemplateFactory.CONFIGS_GOAL_AMOUNT_GROUP,
                 AbstractAmountOfGoalTemplateFactory.CONFIGS_GOAL_AMOUNT_VALUE,
                 AbstractAmountOfGoalTemplateFactory.CONFIGS_GOAL_AMOUNT_UNIT,
@@ -61,8 +61,7 @@ public class TrinkAmountOfGoalTemplateFactory extends AbstractAmountOfGoalTempla
                 new StringTextValue("self-report-question")
                         .setName(AMOUNT_OF_PROPERTY_PREFIX + "self-report-question.name")
                         .setDescription(AMOUNT_OF_PROPERTY_PREFIX + "self-report-question.description")
-                        .setDefaultValue("Wie viele Einheiten hast Du heute getrunken? Bitte trage den Wert ein."),
-                GoalTemplateFactory.SELF_REPORT_TIME_EVENING
+                        .setDefaultValue("Wie viele Einheiten hast Du heute getrunken? Bitte trage den Wert ein.")
         );
     }
 

--- a/studymanager-goaltemplates/src/main/java/io/redlink/more/studymanager/core/factory/GoalTemplateFactory.java
+++ b/studymanager-goaltemplates/src/main/java/io/redlink/more/studymanager/core/factory/GoalTemplateFactory.java
@@ -127,21 +127,4 @@ public abstract class GoalTemplateFactory<C extends GoalTemplate<P>, P extends G
             .setDescription(GLOBAL_PROPERTY_PREFIX + "instanceState.description")
             .setDefaultValue(false);
 
-    /**
-     * Allows to configure a self report time.
-     */
-    public static final Value<String> SELF_REPORT_TIME = new StringValue("self-report-time")
-            .setName(GLOBAL_PROPERTY_PREFIX + "self-report-time.name")
-            .setDescription(GLOBAL_PROPERTY_PREFIX + "self-report-time.description")
-            .setDefaultValue("Abends"); //use evening as default FIXME: change to the correct value
-    /**
-     * Sets the self report time to evening. Just informative. Can not be changed by via configuration
-     */
-    public static final Value<String> SELF_REPORT_TIME_EVENING = new StringValue("self-report-time")
-            .setName(GLOBAL_PROPERTY_PREFIX + "self-report-time.name")
-            .setDescription(GLOBAL_PROPERTY_PREFIX + "self-report-time.description")
-            .setDefaultValue("Abends") // FIXME: change to the correct value
-            .setImmutable(true);
-
-
 }


### PR DESCRIPTION
Some Refinement and fixes to Values:

* added a global check for Immutable. This will now prevent that immutable values can be changed
* Sections and Groups are now `immutable == true`, `required == false ` and have the `defaultValue == null`
    * Removed unnecessary configurations to those instances after this change
* Goal Template values are no longer `immutable` as editing them is implemented in the Frontend
* remove the `self-report-time` values to define times for adherence checks. Setting adherence checks is a direct feature of `GoalTemplate` and therefore the Values where duplications