### PR TITLE
#346: Prevent deletion of used Goal Topics and Adherence Checks

### DIFF
--- a/studymanager-services/src/main/java/io/redlink/more/studymanager/exception/DataConstraintException.java
+++ b/studymanager-services/src/main/java/io/redlink/more/studymanager/exception/DataConstraintException.java
@@ -9,6 +9,7 @@
 package io.redlink.more.studymanager.exception;
 
 import io.redlink.more.studymanager.model.StudyRole;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
@@ -32,4 +33,11 @@ public class DataConstraintException extends RuntimeException {
                         .formatted(userId, StudyRole.STUDY_ADMIN, studyId)
         );
     }
+
+    public static DataConstraintException createWithMessage(long studyId, String item, String reason) {
+        var msg = "Unable to remove %s from study_%d".formatted(item, studyId);
+        return new DataConstraintException(
+                StringUtils.isNotBlank(reason) ? "%s (reason: %s)".formatted(msg, reason) : msg);
+    }
+
 }

--- a/studymanager-services/src/main/java/io/redlink/more/studymanager/repository/goals/GoalConfigurationRepository.java
+++ b/studymanager-services/src/main/java/io/redlink/more/studymanager/repository/goals/GoalConfigurationRepository.java
@@ -1,12 +1,14 @@
 package io.redlink.more.studymanager.repository.goals;
 
 import io.redlink.more.studymanager.exception.BadRequestException;
+import io.redlink.more.studymanager.exception.DataConstraintException;
 import io.redlink.more.studymanager.model.GoalAdherenceCheck;
 import io.redlink.more.studymanager.model.GoalTopic;
 import io.redlink.more.studymanager.model.StudyGoalConfig;
 import io.redlink.more.studymanager.repository.RepositoryUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
@@ -97,7 +99,7 @@ public class GoalConfigurationRepository {
     public void deleteStudyGoalConfig(Long studyId) {
         Integer count = template.queryForObject(COUNT_GOAL_TEMPLATES, Integer.class, studyId);
         if (count != null && count > 0) {
-            throw new BadRequestException("Cannot delete study goal config while GoalTemplates exist for study " + studyId);
+            throw DataConstraintException.createWithMessage(studyId, "Gaol Configuration", "Cannot delete study goal config while GoalTemplates exist for study " + studyId);
         }
         template.update(DELETE_STUDY_GOAL_CONFIG, studyId);
     }
@@ -127,7 +129,11 @@ public class GoalConfigurationRepository {
     }
 
     public void deleteTopic(Long studyId, String key) {
-        template.update(DELETE_TOPIC, studyId, key);
+        try {
+            template.update(DELETE_TOPIC, studyId, key);
+        } catch (DataIntegrityViolationException e) {
+            throw DataConstraintException.createWithMessage(studyId, "Goal Topic " + key, "This Topic is still referenced by GoalTemplates in the Study!");
+        }
     }
 
     @Transactional
@@ -175,11 +181,19 @@ public class GoalConfigurationRepository {
     }
 
     public void deleteChecks(Long studyId) {
-        template.update(DELETE_ADHERENCE_CHECKS, studyId);
+        try {
+            template.update(DELETE_ADHERENCE_CHECKS, studyId);
+        } catch (DataIntegrityViolationException e) {
+            throw DataConstraintException.createWithMessage(studyId, "Adherence Checks", "Adherence Checks are still referenced by GoalTemplates in the Study!");
+        }
     }
 
     public void deleteCheck(Long studyId, Integer checkId) {
-        template.update(DELETE_ADHERENCE_CHECK, studyId, checkId);
+        try {
+            template.update(DELETE_ADHERENCE_CHECK, studyId, checkId);
+        } catch (DataIntegrityViolationException e) {
+            throw DataConstraintException.createWithMessage(studyId, "Adherence Check " + checkId, "This Adherence Check is still referenced by GoalTemplates in the Study!");
+        }
     }
 
     private MapSqlParameterSource toParams(StudyGoalConfig config) {

--- a/studymanager-services/src/main/java/io/redlink/more/studymanager/service/GoalService.java
+++ b/studymanager-services/src/main/java/io/redlink/more/studymanager/service/GoalService.java
@@ -25,6 +25,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -78,6 +79,16 @@ public class GoalService {
     @Transactional
     public Collection<GoalAdherenceCheck> setGoalAdherenceChecks(Long studyId, List<GoalAdherenceCheck> goalAdherenceChecks) {
         studyStateService.assertStudyNotInState(Objects.requireNonNull(studyId), Study.Status.CLOSED);
+        Set<Integer> checkIds = goalAdherenceChecks
+                .stream()
+                .filter(Objects::nonNull)
+                .map(GoalAdherenceCheck::getCheckId)
+                        .collect(Collectors.toSet());
+        //check existing if they are still contained in the parsed list
+        goalConfigRepo.listChecks(studyId).stream()
+                .map(GoalAdherenceCheck::getCheckId)
+                .filter(checkId -> !checkIds.contains(checkId)) //check if we need to delete this one
+                .forEach( checkId -> goalConfigRepo.deleteCheck(studyId, checkId)); // delete
         goalConfigRepo.deleteChecks(studyId);
         return upsertAdherenceChecks(studyId, goalAdherenceChecks);
     }

--- a/studymanager-services/src/main/resources/db/migration/V1_24_1__goals_refinements.sql
+++ b/studymanager-services/src/main/resources/db/migration/V1_24_1__goals_refinements.sql
@@ -1,0 +1,35 @@
+-- changeset yourname:20250521-01
+-- description: Change FKs on goal_template_* tables from ON DELETE CASCADE to RESTRICT
+--              This prevents deletion of GoalTopics and GoalAdherenceChecks that are in use.
+
+-- =============================================
+-- 1. Drop existing FKs (that had ON DELETE CASCADE)
+-- =============================================
+
+ALTER TABLE goal_template_adherence_checks
+    DROP CONSTRAINT IF EXISTS goal_template_adherence_checks_study_id_check_id_fkey;
+
+ALTER TABLE goal_template_topics
+    DROP CONSTRAINT IF EXISTS goal_template_topics_study_id_key_fkey;
+
+-- =============================================
+-- 2. Re-add FKs with RESTRICT (default behavior = block delete)
+-- =============================================
+
+ALTER TABLE goal_template_adherence_checks
+    ADD CONSTRAINT goal_template_adherence_checks_study_id_check_id_fkey
+    FOREIGN KEY (study_id, check_id)
+    REFERENCES goal_adherence_checks(study_id, check_id)
+    ON DELETE RESTRICT;
+
+ALTER TABLE goal_template_topics
+    ADD CONSTRAINT goal_template_topics_study_id_key_fkey
+    FOREIGN KEY (study_id, key)
+    REFERENCES goal_topics(study_id, key)
+    ON DELETE RESTRICT;
+
+COMMENT ON CONSTRAINT goal_template_adherence_checks_study_id_check_id_fkey
+    ON goal_template_adherence_checks IS 'Prevents deletion of a GoalAdherenceCheck if it is referenced by any GoalTemplate';
+
+COMMENT ON CONSTRAINT goal_template_topics_study_id_key_fkey
+    ON goal_template_topics IS 'Prevents deletion of a GoalTopic if it is used by any GoalTemplate';

--- a/studymanager-services/src/test/java/io/redlink/more/studymanager/repository/goals/GoalConfigurationRepositoryTest.java
+++ b/studymanager-services/src/test/java/io/redlink/more/studymanager/repository/goals/GoalConfigurationRepositoryTest.java
@@ -2,8 +2,10 @@ package io.redlink.more.studymanager.repository.goals;
 
 import io.redlink.more.studymanager.configuration.JPAConfiguration;
 import io.redlink.more.studymanager.exception.BadRequestException;
+import io.redlink.more.studymanager.exception.DataConstraintException;
 import io.redlink.more.studymanager.model.*;
 import io.redlink.more.studymanager.repository.StudyRepository;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,6 +18,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.time.LocalTime;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -80,12 +83,12 @@ class GoalConfigurationRepositoryTest {
                 .isEqualTo("Commit1-updated");
 
         assertThat(goalConfigurationRepository.getStudyGoalConfig(study2)).isNull(); // other study
-
+        Assertions.setMaxStackTraceElementsDisplayed(100);
         // Delete guard
         Integer t1 = goalTemplateRepository.insert(new GoalTemplate().setStudyId(study1).setType("test")).getTemplateId();
         assertThatThrownBy(() -> goalConfigurationRepository.deleteStudyGoalConfig(study1))
-                .isInstanceOf(BadRequestException.class)
-                .hasMessageContaining("Cannot delete");
+                .isInstanceOf(DataConstraintException.class)
+                .hasMessageContaining("Unable to remove");
 
         // Delete after removing template
         goalTemplateRepository.deleteGoalTemplate(study1, t1);
@@ -292,6 +295,89 @@ class GoalConfigurationRepositoryTest {
 
         assertThat(goalConfigurationRepository.getTopic(studyB, "hydration").getTitle())
                 .isEqualTo("Updated - Drink More Water");
+    }
+
+    @Test
+    @DisplayName("deleteTopic throws DataConstraintException when topic is used by a GoalTemplate")
+    void testDeleteTopic_ThrowsWhenUsed() {
+        Long studyId = studyRepository.insert(new Study().setContact(new Contact().setPerson("test"))).getStudyId();
+
+        String topicKey = "exercise";
+        // Create topic
+        goalConfigurationRepository.saveTopic(
+                new GoalTopic().setStudyId(studyId).setKey(topicKey).setTitle("Physical Exercise")
+        );
+
+        // Create a GoalTemplate that uses this topic
+        GoalTemplate template = new GoalTemplate()
+                .setStudyId(studyId)
+                .setTitle("Template using exercise topic")
+                .setType("fitness")
+                .setTopicKeys(Set.of(topicKey));
+
+        goalTemplateRepository.insert(template);
+
+        // Attempt to delete the used topic → should fail with DataConstraintException
+        assertThatThrownBy(() -> goalConfigurationRepository.deleteTopic(studyId, topicKey))
+                .isInstanceOf(DataConstraintException.class)
+                .hasMessageContaining("Unable to remove Goal Topic %s from study_%s".formatted(topicKey, studyId))
+                .hasMessageContaining("This Topic is still referenced by GoalTemplates in the Study!");
+    }
+
+    @Test
+    @DisplayName("deleteCheck throws DataConstraintException when check is used by a GoalTemplate")
+    void testDeleteCheck_ThrowsWhenUsed() {
+        Long studyId = studyRepository.insert(new Study().setContact(new Contact().setPerson("test"))).getStudyId();
+
+        // Create adherence check
+        GoalAdherenceCheck check = goalConfigurationRepository.upsertCheck(
+                new GoalAdherenceCheck()
+                        .setStudyId(studyId)
+                        .setCheckId(1)
+                        .setTitle("Morning")
+                        .setTime(LocalTime.of(20, 0))
+        );
+
+        // Create a GoalTemplate that uses this check
+        GoalTemplate template = new GoalTemplate()
+                .setStudyId(studyId)
+                .setTitle("Template using morning check")
+                .setType("habit")
+                .setAdherenceCheckIds(Set.of(check.getCheckId()));
+
+        goalTemplateRepository.insert(template);
+
+        // Attempt to delete the used check → should fail
+        assertThatThrownBy(() -> goalConfigurationRepository.deleteCheck(studyId, check.getCheckId()))
+                .isInstanceOf(DataConstraintException.class)
+                .hasMessageContaining("Unable to remove Adherence Check %s from study_%s".formatted(check.getCheckId(), studyId))
+                .hasMessageContaining("This Adherence Check is still referenced by GoalTemplates in the Study");
+    }
+
+    @Test
+    @DisplayName("deleteTopic and deleteCheck work when not referenced")
+    void testDeleteTopicAndCheck_WhenNotUsed() {
+        Long studyId = studyRepository.insert(new Study().setContact(new Contact().setPerson("test"))).getStudyId();
+
+        // Create unused topic and check
+        goalConfigurationRepository.saveTopic(
+                new GoalTopic().setStudyId(studyId).setKey("unused-topic").setTitle("Unused")
+        );
+
+        GoalAdherenceCheck check = goalConfigurationRepository.upsertCheck(
+                new GoalAdherenceCheck()
+                        .setStudyId(studyId)
+                        .setCheckId(1)
+                        .setTitle("Morning")
+                        .setTime(LocalTime.of(10, 0))
+        );
+
+        // These should succeed
+        goalConfigurationRepository.deleteTopic(studyId, "unused-topic");
+        goalConfigurationRepository.deleteCheck(studyId, check.getCheckId());
+
+        assertThat(goalConfigurationRepository.listTopics(studyId)).isEmpty();
+        assertThat(goalConfigurationRepository.listChecks(studyId)).isEmpty();
     }
 
 }

--- a/studymanager/src/main/java/io/redlink/more/studymanager/controller/studymanager/GoalsApiV1Controller.java
+++ b/studymanager/src/main/java/io/redlink/more/studymanager/controller/studymanager/GoalsApiV1Controller.java
@@ -71,8 +71,9 @@ public class GoalsApiV1Controller implements GoalsApi {
         validateStudyForUser(studyId, currentUser);
         var config = GoalV1Transformer.toStudyGoalConfig(studyGoalConfigDTO, studyId);
         var checks = GoalV1Transformer.toGoalAdherenceChecks(studyGoalConfigDTO, studyId);
-        var updatedConfig = goalService.setGoalConfig(config);
+        //process the adherence checks first as this might result in a CONFLICT if one tries to delete a used one
         var updatedChecks = goalService.setGoalAdherenceChecks(studyId, checks);
+        var updatedConfig = goalService.setGoalConfig(config);
         if(updatedConfig == null) {
             return ResponseEntity.notFound().build();
         } else {

--- a/studymanager/src/main/resources/openapi/StudyManagerAPI.yaml
+++ b/studymanager/src/main/resources/openapi/StudyManagerAPI.yaml
@@ -1360,6 +1360,8 @@ paths:
           description: The referenced study does not exist
         '400':
           description: The parsed study goal configuration or study id was invalid
+        '409':
+          description: If an adherence check is removed that was still used by some GoalTemplate
 
   /studies/{studyId}/goals/config/categories/topic:
     post:
@@ -1423,6 +1425,8 @@ paths:
           description: action deleted successfully
         '400':
           description: bad request
+        '409':
+          description: conflict - deleting the goal topic is not possible while it is used by a goal template
 
 
   /studies/{studyId}/goals/templates:


### PR DESCRIPTION
This changes AdherenceChecks and GoalTopics so that they cannot be deleted if they are still used with a GoalTemplate.  In such cases a `409 CONFLICT` response is sent to indicate the conflict.