### PR TITLE
Fix 1.24.0 database migration

### DIFF
--- a/studymanager-services/src/main/resources/db/migration/V1_24_0__goals.sql
+++ b/studymanager-services/src/main/resources/db/migration/V1_24_0__goals.sql
@@ -107,25 +107,3 @@ CREATE TABLE goal (
     FOREIGN KEY (study_id, participant_id) REFERENCES participants(study_id, participant_id) ON DELETE CASCADE,
     FOREIGN KEY (study_id, template_id) REFERENCES goal_templates(study_id, template_id) ON DELETE CASCADE
 );
-
-
-CREATE TABLE IF NOT EXISTS nvpairs_goaltemplates (
-    study_id BIGINT NOT NULL,
-    template_id INT,
-    name VARCHAR,
-    value bytea NOT NULL,
-
-    PRIMARY KEY (study_id, template_id, name),
-    FOREIGN KEY (study_id, template_id) REFERENCES goal_templates(study_id, template_id) ON DELETE CASCADE
-);
-
-CREATE TABLE IF NOT EXISTS nvpairs_goals (
-     study_id BIGINT NOT NULL,
-     goal_id INT,
-     name VARCHAR,
-     value bytea NOT NULL,
-
-     PRIMARY KEY (study_id, goal_id, name),
-     FOREIGN KEY (study_id, goal_id) REFERENCES goal(study_id, goal_id) ON DELETE CASCADE
-);
-

--- a/studymanager-services/src/main/resources/db/migration/V1_24_2__goal_nvpairs.sql
+++ b/studymanager-services/src/main/resources/db/migration/V1_24_2__goal_nvpairs.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS nvpairs_goaltemplates (
+    study_id BIGINT NOT NULL,
+    template_id INT,
+    name VARCHAR,
+    value bytea NOT NULL,
+
+    PRIMARY KEY (study_id, template_id, name),
+    FOREIGN KEY (study_id, template_id) REFERENCES goal_templates(study_id, template_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS nvpairs_goals (
+     study_id BIGINT NOT NULL,
+     goal_id INT,
+     name VARCHAR,
+     value bytea NOT NULL,
+
+     PRIMARY KEY (study_id, goal_id, name),
+     FOREIGN KEY (study_id, goal_id) REFERENCES goal(study_id, goal_id) ON DELETE CASCADE
+);
+


### PR DESCRIPTION
This should fix the database migration caused by the Goal Repository branch merged before the Goal Service Impl branch that extended the 1.24.0 migration file by the two nvpair tables used by the GoalSDK extension