### PR TITLE
#390: fix updating adherence checks on set study config

### DIFF
--- a/studymanager-services/src/main/java/io/redlink/more/studymanager/repository/goals/GoalTemplateRepository.java
+++ b/studymanager-services/src/main/java/io/redlink/more/studymanager/repository/goals/GoalTemplateRepository.java
@@ -68,7 +68,6 @@ public class GoalTemplateRepository {
                      gt.type, gt.kind, gt.study_group_id,
                      gt.properties, gt.created, gt.modified""";
 
-    // Same fix applied to the "ForGroup" query
     private static final String LIST_GOAL_TEMPLATES_FOR_GROUP = """
             SELECT gt.*,
                    ARRAY_AGG(gtog.observation_group_id) FILTER (WHERE gtog.observation_group_id IS NOT NULL) AS observation_group_ids,

--- a/studymanager-services/src/main/java/io/redlink/more/studymanager/service/GoalService.java
+++ b/studymanager-services/src/main/java/io/redlink/more/studymanager/service/GoalService.java
@@ -79,17 +79,15 @@ public class GoalService {
     @Transactional
     public Collection<GoalAdherenceCheck> setGoalAdherenceChecks(Long studyId, List<GoalAdherenceCheck> goalAdherenceChecks) {
         studyStateService.assertStudyNotInState(Objects.requireNonNull(studyId), Study.Status.CLOSED);
-        Set<Integer> checkIds = goalAdherenceChecks
-                .stream()
+        Set<Integer> checkIds = goalAdherenceChecks.stream()
                 .filter(Objects::nonNull)
                 .map(GoalAdherenceCheck::getCheckId)
-                        .collect(Collectors.toSet());
+                .collect(Collectors.toSet());
         //check existing if they are still contained in the parsed list
         goalConfigRepo.listChecks(studyId).stream()
                 .map(GoalAdherenceCheck::getCheckId)
                 .filter(checkId -> !checkIds.contains(checkId)) //check if we need to delete this one
                 .forEach( checkId -> goalConfigRepo.deleteCheck(studyId, checkId)); // delete
-        goalConfigRepo.deleteChecks(studyId);
         return upsertAdherenceChecks(studyId, goalAdherenceChecks);
     }
 


### PR DESCRIPTION
Forgot to delete the deleteAll after refactoring this method as part of the last pull request. NOTE: refactoring fixed an unnoticed bug where the CASCADE DELETE removed all adherence chack assignments from GoalTemplates while updating the study config, as this method first deleted all adherence checks and later added them back :(