### PR TITLE
#388: A quick fix for the data export dialog

### DIFF
--- a/studymanager-services/src/main/java/io/redlink/more/studymanager/model/StudyComponent.java
+++ b/studymanager-services/src/main/java/io/redlink/more/studymanager/model/StudyComponent.java
@@ -1,0 +1,8 @@
+package io.redlink.more.studymanager.model;
+
+public record StudyComponent(
+    Long studyId,
+    Integer componentId,
+    String type,
+    String title
+) {}

--- a/studymanager-services/src/main/java/io/redlink/more/studymanager/repository/StudyComponentRepository.java
+++ b/studymanager-services/src/main/java/io/redlink/more/studymanager/repository/StudyComponentRepository.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Elastic License 2.0.
+ */
+package io.redlink.more.studymanager.repository;
+
+import io.redlink.more.studymanager.model.StudyComponent;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Component
+public class StudyComponentRepository {
+
+    private static final Map<String, String> COMPONENT_QUERIES = Map.of(
+            "studygroup", """
+                SELECT 'studygroup' as type, study_id, study_group_id as id, title
+                FROM study_groups
+                """,
+
+            "observation", """
+                SELECT 'observation' as type, study_id, observation_id as id, title
+                FROM observations
+                """,
+
+            "intervention", """
+                SELECT 'intervention' as type, study_id, intervention_id as id, title
+                FROM interventions
+                """,
+
+            "participant", """
+                SELECT 'participant' as type, study_id, participant_id as id, alias as title
+                FROM participants
+                """,
+
+            "observationgroup", """
+                SELECT 'observationgroup' as type, study_id, observation_group_id as id, title
+                FROM observation_groups
+                """,
+
+            "goaltemplate", """
+                SELECT 'goaltemplate' as type, study_id, template_id as id, title
+                FROM goal_templates
+                """,
+
+            "goal", """
+                SELECT 'goal' as type, g.study_id, g.goal_id as id, gt.title
+                FROM goal g
+                JOIN goal_templates gt ON g.study_id = gt.study_id AND g.template_id = gt.template_id
+                """
+    );
+
+    private static final String ALL_TYPES_SQL = buildAllTypesSql();
+
+    private final JdbcTemplate template;
+
+    public StudyComponentRepository(JdbcTemplate template) {
+        this.template = template;
+    }
+
+    public Map<String, Map<Integer, StudyComponent>> getComponents(Long studyId) {
+        return getComponents(studyId, (Set<String>) null);
+    }
+
+    public Map<String, Map<Integer, StudyComponent>> getComponents(Long studyId, Set<String> includedComponentTypes) {
+        String baseSql = buildSqlForTypes(includedComponentTypes);
+        String sql = """
+                SELECT * FROM (
+                    %s
+                ) AS components
+                WHERE study_id = ?
+                """.formatted(baseSql);
+
+        List<StudyComponent> components;
+        if (includedComponentTypes != null && !includedComponentTypes.isEmpty()) {
+            sql += " AND type = ANY(?)";
+            components = template.query(sql, getStudyComponentRowMapper(), studyId, includedComponentTypes.toArray(new String[0]));
+        } else {
+            components = template.query(sql, getStudyComponentRowMapper(), studyId);
+        }
+
+        Map<String, Map<Integer, StudyComponent>> result = new HashMap<>();
+        for (StudyComponent sc : components) {
+            result.computeIfAbsent(sc.type(), k -> new HashMap<>())
+                    .put(sc.componentId(), sc);
+        }
+        return result;
+    }
+
+    public Map<Integer, StudyComponent> getComponents(Long studyId, String type) {
+        String fragment = COMPONENT_QUERIES.get(type);
+        if (fragment == null) {
+            return Map.of();
+        }
+
+        String sql = """
+                SELECT * FROM (
+                    %s
+                ) AS components
+                WHERE study_id = ?
+                """.formatted(fragment);
+
+        List<StudyComponent> list = template.query(sql, getStudyComponentRowMapper(), studyId);
+
+        Map<Integer, StudyComponent> map = new HashMap<>();
+        for (StudyComponent sc : list) {
+            map.put(sc.componentId(), sc);
+        }
+        return map;
+    }
+
+    public StudyComponent getComponent(Long studyId, String type, Integer id) {
+        String fragment = COMPONENT_QUERIES.get(type);
+        if (fragment == null) {
+            return null;
+        }
+
+        String sql = """
+                SELECT * FROM (
+                    %s
+                ) AS components
+                WHERE study_id = ? AND id = ?
+                """.formatted(fragment);
+
+        try {
+            return template.queryForObject(sql, getStudyComponentRowMapper(), studyId, id);
+        } catch (EmptyResultDataAccessException e) {
+            return null;
+        }
+    }
+
+    private static RowMapper<StudyComponent> getStudyComponentRowMapper() {
+        return (rs, rowNum) -> new StudyComponent(
+                rs.getLong("study_id"),
+                rs.getInt("id"),
+                rs.getString("type"),
+                rs.getString("title")
+        );
+    }
+
+    private static String buildAllTypesSql() {
+        return COMPONENT_QUERIES.values().stream()
+                .collect(Collectors.joining(" UNION ALL\n"));
+    }
+
+    private String buildSqlForTypes(Set<String> types) {
+        if (types == null || types.isEmpty()) {
+            return ALL_TYPES_SQL;
+        }
+
+        return types.stream()
+                .filter(COMPONENT_QUERIES::containsKey)
+                .map(COMPONENT_QUERIES::get)
+                .collect(Collectors.joining(" UNION ALL\n"));
+    }
+}

--- a/studymanager-services/src/main/java/io/redlink/more/studymanager/service/ElasticService.java
+++ b/studymanager-services/src/main/java/io/redlink/more/studymanager/service/ElasticService.java
@@ -46,11 +46,17 @@ import java.time.Instant;
 import java.util.*;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 @Service
 @EnableConfigurationProperties({ElasticProperties.class})
 public class ElasticService {
+
+    // For observations we accept raw integer ids as well as `observation_<id>`
+    private static final Pattern OBSERVATION_ID_PATTERN = Pattern.compile("^(?:observation_)?(\\d+)$");
+    // For goal templates we accept only `goaltemplate_<id>`
+    private static final Pattern GOALTEMPLATE_ID_PATTERN = Pattern.compile("^goaltemplate_?(\\d+)$");
 
     private static final Logger LOG = LoggerFactory.getLogger(ElasticService.class);
 
@@ -288,7 +294,7 @@ public class ElasticService {
                                                 )
                                 )
                 );
-        try{
+        try {
             List<ParticipationData> participationDataList = new ArrayList<>();
 
             List<StringTermsBucket> observationBuckets =  client.search(builder.build(), Map.class)
@@ -298,6 +304,11 @@ public class ElasticService {
                     .buckets()
                     .array();
             for(StringTermsBucket observation : observationBuckets){
+                var observationIdMatcher = OBSERVATION_ID_PATTERN.matcher(observation.key().stringValue());
+                if(!observationIdMatcher.find()){
+                    continue; // ignore everything that is no observation (for now)
+                }
+                int observationId = Integer.parseInt(observationIdMatcher.group(1));
                 List<StringTermsBucket> participantBuckets = observation
                         .aggregations()
                         .get("participant_ids")
@@ -326,7 +337,7 @@ public class ElasticService {
                                      .substring(12)), null);
                     assert lastDataReceived != null;
                     participationDataList.add(new ParticipationData(
-                            new ParticipationData.NamedId(Integer.parseInt(observation.key().stringValue().replaceAll("observation_", "")), null),
+                            new ParticipationData.NamedId(observationId, null),
                             "observationType",
                             new ParticipationData.NamedId(Integer.parseInt(participant.key().stringValue().substring(12)), null),
                             studyGroup,
@@ -335,7 +346,7 @@ public class ElasticService {
                 }
             }
             return participationDataList;
-        }catch (IOException | ElasticsearchException e) {
+        } catch (IOException | ElasticsearchException e) {
             if (isElasticIndexNotFound(e)) {
                 return List.of();
             }

--- a/studymanager-services/src/main/java/io/redlink/more/studymanager/service/ElasticService.java
+++ b/studymanager-services/src/main/java/io/redlink/more/studymanager/service/ElasticService.java
@@ -34,6 +34,7 @@ import io.redlink.more.studymanager.model.data.ParticipationData;
 import io.redlink.more.studymanager.model.data.SimpleDataPoint;
 import io.redlink.more.studymanager.properties.ElasticProperties;
 import io.redlink.more.studymanager.utils.MapperUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -46,6 +47,7 @@ import java.time.Instant;
 import java.util.*;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -54,7 +56,7 @@ import java.util.stream.Collectors;
 public class ElasticService {
 
     // For observations we accept raw integer ids as well as `observation_<id>`
-    private static final Pattern OBSERVATION_ID_PATTERN = Pattern.compile("^(?:observation_)?(\\d+)$");
+    private static final Pattern OBSERVATION_TYPE_ID_PATTERN = Pattern.compile("\"^(?:(?<type>[a-z]+)_)?(?<id>\\d+)$\"");
     // For goal templates we accept only `goaltemplate_<id>`
     private static final Pattern GOALTEMPLATE_ID_PATTERN = Pattern.compile("^goaltemplate_?(\\d+)$");
 
@@ -304,11 +306,11 @@ public class ElasticService {
                     .buckets()
                     .array();
             for(StringTermsBucket observation : observationBuckets){
-                var observationIdMatcher = OBSERVATION_ID_PATTERN.matcher(observation.key().stringValue());
-                if(!observationIdMatcher.find()){
-                    continue; // ignore everything that is no observation (for now)
+                Map.Entry<String,Integer> obsTypeId = parseObservationTypeAndId(observation.key().stringValue());
+                if(obsTypeId == null || !obsTypeId.getKey().equals("observation")) {
+                    continue; //unable to parse observation id ...
                 }
-                int observationId = Integer.parseInt(observationIdMatcher.group(1));
+                int observationId = obsTypeId.getValue();
                 List<StringTermsBucket> participantBuckets = observation
                         .aggregations()
                         .get("participant_ids")
@@ -499,5 +501,25 @@ public class ElasticService {
     static <E extends Exception, T extends Exception> void handleIndexNotFoundException(E e, Function<E, T> exceptionWrapper) throws T {
         if (!isElasticIndexNotFound(e))
             throw exceptionWrapper.apply(e);
+    }
+
+    /**
+     * Parses an ID string and returns the type and numeric ID.
+     *
+     * @param idStr the input string (e.g. "42", "observation_41", "goaltemplate_40")
+     * @return Map.Entry with type (String) and id (Integer)
+     * @throws IllegalArgumentException if the string doesn't match the expected format
+     */
+    private static Map.Entry<String, Integer> parseObservationTypeAndId(String idStr) {
+        if (StringUtils.isBlank(idStr)) {
+            throw new IllegalArgumentException("ID string cannot be null or empty");
+        }
+       Matcher matcher = OBSERVATION_TYPE_ID_PATTERN.matcher(idStr);
+        if (!matcher.matches()) {
+            return null;
+        }
+        String type = matcher.group("type");
+        return new AbstractMap.SimpleEntry<>(
+                type == null ? "observation" : type, Integer.parseInt(matcher.group("id")));
     }
 }

--- a/studymanager-services/src/main/java/io/redlink/more/studymanager/service/StudyComponentService.java
+++ b/studymanager-services/src/main/java/io/redlink/more/studymanager/service/StudyComponentService.java
@@ -1,0 +1,4 @@
+package io.redlink.more.studymanager.service;
+
+public class StudyComponentService {
+}

--- a/studymanager-services/src/test/java/io/redlink/more/studymanager/repository/StudyComponentRepositoryTest.java
+++ b/studymanager-services/src/test/java/io/redlink/more/studymanager/repository/StudyComponentRepositoryTest.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ * contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ * for Digital Health and Prevention -- A research institute of the
+ * Ludwig Boltzmann Gesellschaft, Österreichische Vereinigung zur
+ * Förderung der wissenschaftlichen Forschung).
+ * Licensed under the Elastic License 2.0.
+ */
+package io.redlink.more.studymanager.repository;
+
+import io.redlink.more.studymanager.configuration.JPAConfiguration;
+import io.redlink.more.studymanager.core.properties.GoalProperties;
+import io.redlink.more.studymanager.model.*;
+import io.redlink.more.studymanager.repository.goals.GoalRepository;
+import io.redlink.more.studymanager.repository.goals.GoalTemplateRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Testcontainers
+@EnableAutoConfiguration
+@ContextConfiguration(classes = {
+        StudyComponentRepository.class,
+        StudyRepository.class,
+        StudyGroupRepository.class,
+        ObservationRepository.class,
+        InterventionRepository.class,
+        ParticipantRepository.class,
+        ObservationGroupRepository.class,
+        GoalTemplateRepository.class,
+        GoalRepository.class,
+        JPAConfiguration.class
+})
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@ActiveProfiles("test-containers-flyway")
+class StudyComponentRepositoryTest {
+
+    @Autowired
+    private StudyComponentRepository studyComponentRepository;
+
+    @Autowired
+    private StudyRepository studyRepository;
+
+    @Autowired
+    private StudyGroupRepository studyGroupRepository;
+
+    @Autowired
+    private ObservationRepository observationRepository;
+
+    @Autowired
+    private InterventionRepository interventionRepository;
+
+    @Autowired
+    private ParticipantRepository participantRepository;
+
+    @Autowired
+    private ObservationGroupRepository observationGroupRepository;
+
+    @Autowired
+    private GoalTemplateRepository goalTemplateRepository;
+
+    @Autowired
+    private GoalRepository goalRepository;
+
+    @BeforeEach
+    void deleteAll() {
+        goalRepository.clear();
+        goalTemplateRepository.clear();
+        observationGroupRepository.clear();
+        participantRepository.clear();
+        interventionRepository.clear();
+        observationRepository.clear();
+        studyGroupRepository.clear();
+    }
+
+    @Test
+    @DisplayName("Study components are retrieved correctly by study")
+    void testGetComponents() {
+        Long studyId = studyRepository.insert(new Study()
+                        .setContact(new Contact().setPerson("test").setEmail("test")))
+                .getStudyId();
+
+        // 1. Study Group
+        Integer studyGroupId = studyGroupRepository.insert(new StudyGroup()
+                        .setStudyId(studyId)
+                        .setTitle("Test Study Group")
+                        .setPurpose("Test purpose"))
+                .getStudyGroupId();
+
+        // 2. Observation
+        Integer observationId = observationRepository.insert(new Observation()
+                        .setStudyId(studyId)
+                        .setTitle("Test Observation")
+                        .setType("questionnaire")
+                        .setHidden(false)
+                        .setPurpose("Test obs purpose"))
+                .getObservationId();
+
+        // 3. Intervention
+        Integer interventionId = interventionRepository.insert(new Intervention()
+                        .setStudyId(studyId)
+                        .setTitle("Test Intervention")
+                        .setPurpose("Test intv purpose"))
+                .getInterventionId();
+
+        // 4. Participant
+        Integer participantId = participantRepository.insert(new Participant()
+                        .setStudyId(studyId)
+                        .setAlias("Test Participant")
+                        .setRegistrationToken("TEST123"))
+                .getParticipantId();
+
+        // 5. Observation Group
+        Integer observationGroupId = observationGroupRepository.insert(new ObservationGroup()
+                        .setStudyId(studyId)
+                        .setTitle("Test Observation Group")
+                        .setPurpose("Test og purpose"))
+                .getObservationGroupId();
+
+        // 6. Goal Template
+        Integer goalTemplateId = goalTemplateRepository.insert(new GoalTemplate()
+                        .setStudyId(studyId)
+                        .setTitle("Test Goal Template")
+                        .setType("some-type"))
+                .getTemplateId();
+
+        // 7. Goal (linked to template)
+        Integer goalId = goalRepository.insert(new Goal()
+                        .setStudyId(studyId)
+                        .setParticipantId(participantId)
+                        .setTemplateId(goalTemplateId)
+                        .setProperties(new GoalProperties(Map.of("progress", 50))))
+                .getGoalId();
+
+        // === Verify full retrieval ===
+        Map<String, Map<Integer, StudyComponent>> allComponents = studyComponentRepository.getComponents(studyId);
+
+        assertThat(allComponents).containsKeys(
+                "studygroup", "observation", "intervention", "participant",
+                "observationgroup", "goaltemplate", "goal"
+        );
+
+        assertThat(allComponents.get("studygroup").get(studyGroupId).title()).isEqualTo("Test Study Group");
+        assertThat(allComponents.get("observation").get(observationId).title()).isEqualTo("Test Observation");
+        assertThat(allComponents.get("intervention").get(interventionId).title()).isEqualTo("Test Intervention");
+        assertThat(allComponents.get("participant").get(participantId).title()).isEqualTo("Test Participant");
+        assertThat(allComponents.get("observationgroup").get(observationGroupId).title()).isEqualTo("Test Observation Group");
+        assertThat(allComponents.get("goaltemplate").get(goalTemplateId).title()).isEqualTo("Test Goal Template");
+        assertThat(allComponents.get("goal").get(goalId).title()).isEqualTo("Test Goal Template"); // title comes from template
+
+        // Test filtered by type
+        Map<String, Map<Integer, StudyComponent>> filtered = studyComponentRepository.getComponents(
+                studyId, Set.of("participant", "goaltemplate", "goal")
+        );
+
+        assertThat(filtered).containsOnlyKeys("participant", "goaltemplate", "goal");
+        assertThat(filtered.get("goal")).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("Single component retrieval works")
+    void testGetComponent() {
+        Long studyId = studyRepository.insert(new Study()
+                        .setContact(new Contact().setPerson("test").setEmail("test")))
+                .getStudyId();
+
+        Integer participantId = participantRepository.insert(new Participant()
+                        .setStudyId(studyId)
+                        .setAlias("Single Test Participant")
+                        .setRegistrationToken("TEST456"))
+                .getParticipantId();
+
+        StudyComponent component = studyComponentRepository.getComponent(studyId, "participant", participantId);
+
+        assertThat(component).isNotNull();
+        assertThat(component.studyId()).isEqualTo(studyId);
+        assertThat(component.componentId()).isEqualTo(participantId);
+        assertThat(component.type()).isEqualTo("participant");
+        assertThat(component.title()).isEqualTo("Single Test Participant");
+
+        // Non-existing returns null
+        assertThat(studyComponentRepository.getComponent(studyId, "participant", 99999)).isNull();
+    }
+
+    @Test
+    @DisplayName("Get components by single type")
+    void testGetComponentsByType() {
+        Long studyId = studyRepository.insert(new Study()
+                        .setContact(new Contact().setPerson("test").setEmail("test")))
+                .getStudyId();
+
+        participantRepository.insert(new Participant()
+                .setStudyId(studyId)
+                .setAlias("P1")
+                .setRegistrationToken("T1"));
+
+        participantRepository.insert(new Participant()
+                .setStudyId(studyId)
+                .setAlias("P2")
+                .setRegistrationToken("T2"));
+
+        Map<Integer, StudyComponent> participants = studyComponentRepository.getComponents(studyId, "participant");
+
+        assertThat(participants).hasSize(2);
+        assertThat(participants.values()).allMatch(sc -> "participant".equals(sc.type()));
+    }
+}


### PR DESCRIPTION
Until the data export can support goalTemplates and goals we want to filter those data do not break existing functionality