### PR TITLE
#399 medication and boolean goal template

### DIFF
--- a/studymanager-core/src/main/java/io/redlink/more/studymanager/core/properties/model/BooleanValue.java
+++ b/studymanager-core/src/main/java/io/redlink/more/studymanager/core/properties/model/BooleanValue.java
@@ -22,4 +22,9 @@ public class BooleanValue extends Value<Boolean> {
     public String getType() {
         return "BOOLEAN";
     }
+
+    @Override
+    public Value<Boolean> clone() {
+        return copyState(new BooleanValue(getId()));
+    }
 }

--- a/studymanager-core/src/main/java/io/redlink/more/studymanager/core/properties/model/ChoiceValue.java
+++ b/studymanager-core/src/main/java/io/redlink/more/studymanager/core/properties/model/ChoiceValue.java
@@ -8,13 +8,23 @@
  */
 package io.redlink.more.studymanager.core.properties.model;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class ChoiceValue extends Value<String> {
-    private List<String> options;
+    private List<String> options =  new ArrayList<>();
 
     public ChoiceValue(String id) {
         super(id);
+    }
+
+    public List<String> getOptions() {
+        return options;
+    }
+
+    public ChoiceValue setOptions(List<String> options) {
+        this.options = options == null ? new ArrayList<>() : options;
+        return this;
     }
 
     @Override
@@ -25,5 +35,11 @@ public class ChoiceValue extends Value<String> {
     @Override
     public Class<String> getValueType() {
         return String.class;
+    }
+
+    @Override
+    public Value<String> clone() {
+        return copyState(new ChoiceValue(getId())
+                .setOptions(getOptions()));
     }
 }

--- a/studymanager-core/src/main/java/io/redlink/more/studymanager/core/properties/model/ConfigSection.java
+++ b/studymanager-core/src/main/java/io/redlink/more/studymanager/core/properties/model/ConfigSection.java
@@ -52,4 +52,11 @@ public class ConfigSection extends Value<Void> {
     public final boolean isRequired() {
         return false;
     }
+
+    @Override
+    public Value<Void> clone() {
+        return copyState(new ConfigSection(getId()));
+    }
+
+
 }

--- a/studymanager-core/src/main/java/io/redlink/more/studymanager/core/properties/model/IntegerRangeValue.java
+++ b/studymanager-core/src/main/java/io/redlink/more/studymanager/core/properties/model/IntegerRangeValue.java
@@ -60,4 +60,10 @@ public class IntegerRangeValue extends Value<IntegerRange> {
         return this;
     }
 
+    @Override
+    public Value<IntegerRange> clone() {
+        return copyState(new IntegerRangeValue(getId())
+                .setMax(getMax())
+                .setMin(getMin()));
+    }
 }

--- a/studymanager-core/src/main/java/io/redlink/more/studymanager/core/properties/model/IntegerValue.java
+++ b/studymanager-core/src/main/java/io/redlink/more/studymanager/core/properties/model/IntegerValue.java
@@ -54,4 +54,12 @@ public class IntegerValue extends Value<Integer> {
         this.max = max;
         return this;
     }
+
+    @Override
+    public Value<Integer> clone() {
+        return copyState(new IntegerValue(getId())
+                .setMax(getMax())
+                .setMin(getMin()));
+    }
+
 }

--- a/studymanager-core/src/main/java/io/redlink/more/studymanager/core/properties/model/NamedIntegerRangeValue.java
+++ b/studymanager-core/src/main/java/io/redlink/more/studymanager/core/properties/model/NamedIntegerRangeValue.java
@@ -61,4 +61,11 @@ public class NamedIntegerRangeValue extends Value<NamedIntegerRange> {
         return this;
     }
 
+    @Override
+    public Value<NamedIntegerRange> clone() {
+        return copyState(new NamedIntegerRangeValue(getId())
+                .setMax(getMax())
+                .setMin(getMin()));
+    }
+
 }

--- a/studymanager-core/src/main/java/io/redlink/more/studymanager/core/properties/model/ObjectValue.java
+++ b/studymanager-core/src/main/java/io/redlink/more/studymanager/core/properties/model/ObjectValue.java
@@ -22,4 +22,10 @@ public class ObjectValue extends Value<Object> {
     public String getType() {
         return "OBJECT";
     }
+
+    @Override
+    public Value<Object> clone() {
+        return copyState(new ObjectValue(getId()));
+    }
+
 }

--- a/studymanager-core/src/main/java/io/redlink/more/studymanager/core/properties/model/StringListValue.java
+++ b/studymanager-core/src/main/java/io/redlink/more/studymanager/core/properties/model/StringListValue.java
@@ -46,4 +46,11 @@ public class StringListValue extends Value<List> {
         this.maxSize = maxSize;
         return this;
     }
+
+    @Override
+    public Value<List> clone() {
+        return copyState(new StringListValue(getId())
+                .setMinSize(getMinSize())
+                .setMaxSize(getMaxSize()));
+    }
 }

--- a/studymanager-core/src/main/java/io/redlink/more/studymanager/core/properties/model/StringTemplateValue.java
+++ b/studymanager-core/src/main/java/io/redlink/more/studymanager/core/properties/model/StringTemplateValue.java
@@ -3,6 +3,7 @@ package io.redlink.more.studymanager.core.properties.model;
 import io.redlink.more.studymanager.core.validation.ValidationIssue;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -24,6 +25,10 @@ public class StringTemplateValue extends StringValue {
     public StringTemplateValue(String id, Set<String> allowList) {
         super(id);
         this.allowList = allowList;
+    }
+
+    public Set<String> getAllowList() {
+        return allowList;
     }
 
     @Override
@@ -52,6 +57,11 @@ public class StringTemplateValue extends StringValue {
             }
         }
         return super.doValidate(value);
+    }
+
+    @Override
+    public Value<String> clone() {
+        return copyState(new StringTemplateValue(getId(),getAllowList()));
     }
 
 }

--- a/studymanager-core/src/main/java/io/redlink/more/studymanager/core/properties/model/StringTextValue.java
+++ b/studymanager-core/src/main/java/io/redlink/more/studymanager/core/properties/model/StringTextValue.java
@@ -22,4 +22,10 @@ public class StringTextValue extends Value<String> {
     public Class<String> getValueType() {
         return String.class;
     }
+
+    @Override
+    public Value<String> clone() {
+        return copyState(new StringTextValue(getId()));
+    }
+
 }

--- a/studymanager-core/src/main/java/io/redlink/more/studymanager/core/properties/model/StringValue.java
+++ b/studymanager-core/src/main/java/io/redlink/more/studymanager/core/properties/model/StringValue.java
@@ -32,4 +32,10 @@ public class StringValue extends Value<String> {
     public Class<String> getValueType() {
         return String.class;
     }
+
+    @Override
+    public Value<String> clone() {
+        return copyState(new StringValue(getId()));
+    }
+
 }

--- a/studymanager-core/src/main/java/io/redlink/more/studymanager/core/properties/model/Value.java
+++ b/studymanager-core/src/main/java/io/redlink/more/studymanager/core/properties/model/Value.java
@@ -18,7 +18,7 @@ import io.redlink.more.studymanager.core.validation.ValidationIssue;
 import java.util.Objects;
 import java.util.function.Function;
 
-public abstract class Value<T> {
+public abstract class Value<T> implements Cloneable{
     private final String id;
     private String name;
     private String description;
@@ -135,6 +135,25 @@ public abstract class Value<T> {
     public Value<T> setValidationFunction(Function<T, ValidationIssue> validationFunction) {
         this.validationFunction = validationFunction;
         return this;
+    }
+
+    /**
+     * Creates a copy of the current Value
+     * @return
+     */
+    public Value<T> copyOf(){
+        return this.clone();
+    }
+
+    public abstract Value<T> clone();
+
+    protected Value<T> copyState(Value<T> target) {
+        target.setName(getName());
+        target.setDescription(getDescription());
+        target.setRequired(isRequired());
+        target.setImmutable(isImmutable());
+        target.setDefaultValue(getDefaultValue());
+        return target;
     }
 
     @Override

--- a/studymanager-core/src/main/java/io/redlink/more/studymanager/core/properties/model/ValueGroup.java
+++ b/studymanager-core/src/main/java/io/redlink/more/studymanager/core/properties/model/ValueGroup.java
@@ -61,4 +61,9 @@ public class ValueGroup extends Value<Void> {
         return false;
     }
 
+    @Override
+    public Value<Void> clone() {
+        return copyState(new ValueGroup(getId()));
+    }
+
 }

--- a/studymanager-goaltemplates/src/main/java/io/redlink/more/studymanager/component/goaltemplate/AbstractBooleanGoalTemplateFactory.java
+++ b/studymanager-goaltemplates/src/main/java/io/redlink/more/studymanager/component/goaltemplate/AbstractBooleanGoalTemplateFactory.java
@@ -1,0 +1,79 @@
+package io.redlink.more.studymanager.component.goaltemplate;
+
+import io.redlink.more.studymanager.core.component.GoalTemplate;
+import io.redlink.more.studymanager.core.factory.GoalTemplateFactory;
+import io.redlink.more.studymanager.core.measurement.Measurement;
+import io.redlink.more.studymanager.core.measurement.MeasurementSet;
+import io.redlink.more.studymanager.core.properties.GoalTemplateProperties;
+import io.redlink.more.studymanager.core.properties.model.BooleanValue;
+import io.redlink.more.studymanager.core.properties.model.ConfigSection;
+import io.redlink.more.studymanager.core.properties.model.IntegerRange;
+import io.redlink.more.studymanager.core.properties.model.IntegerRangeValue;
+import io.redlink.more.studymanager.core.properties.model.StringTextValue;
+import io.redlink.more.studymanager.core.properties.model.StringValue;
+import io.redlink.more.studymanager.core.properties.model.Value;
+import io.redlink.more.studymanager.core.properties.model.ValueGroup;
+
+import java.util.Objects;
+import java.util.Set;
+
+public abstract class AbstractBooleanGoalTemplateFactory<C extends GoalTemplate<P>, P extends GoalTemplateProperties> extends GoalTemplateFactory<C, P> {
+
+    public static final String FIELD_QUESTION =  "question";
+    public static final String FIELD_STATE =  "state";
+    public static final String FIELD_DESIRED =  "desired";
+    public static final String FIELD_TARGET_DAYS_IN_WEEK =  "targetDays";
+
+    private static final MeasurementSet measurements = new MeasurementSet(
+            "SELF_ASSESSMENT", Set.of(
+                    new Measurement(FIELD_GOAL_KIND, Measurement.Type.STRING),
+                    new Measurement(FIELD_GOAL_CATEGORY, Measurement.Type.STRING),
+                    new Measurement(FIELD_QUESTION, Measurement.Type.STRING),
+                    new Measurement(FIELD_STATE, Measurement.Type.BOOLEAN),
+                    new Measurement(FIELD_DESIRED, Measurement.Type.BOOLEAN),
+                    new Measurement(FIELD_TARGET_DAYS_IN_WEEK, Measurement.Type.INTEGER)));
+
+    protected static final String BOOLEAN_PROPERTY_PREFIX = GOAL_TEMPLATE_PROPERTY_PREFIX + "boolean.";
+
+    protected static final Value<Void> CONFIG_SECTION_CONFIGURATION = new ConfigSection("configuration")
+            .setName(BOOLEAN_PROPERTY_PREFIX + "section.configuration.name")
+            .setDescription(BOOLEAN_PROPERTY_PREFIX + "section.configuration.description");
+    protected static final Value<Void> CONFIG_SECTION_GOAL_CONFIGURATION = new ConfigSection("goal-configuration")
+            .setName(BOOLEAN_PROPERTY_PREFIX + "section.goal.name")
+            .setDescription(BOOLEAN_PROPERTY_PREFIX + "section.goal.description");
+    protected static final Value<Void> CONFIG_SECTION_STATUS = new ConfigSection("status-texts")
+            .setName(BOOLEAN_PROPERTY_PREFIX + "section.status-texts.name")
+            .setDescription(BOOLEAN_PROPERTY_PREFIX + "section.status-texts.description");
+    protected static final Value<Void> CONFIG_SECTION_SELF_REPORT = new ConfigSection("self-report")
+            .setName(BOOLEAN_PROPERTY_PREFIX + "section.self-report.name")
+            .setDescription(BOOLEAN_PROPERTY_PREFIX + "section.self-report.description");
+
+    protected static final Value<Boolean> CONFIGS_GOAL_DESIRED = new BooleanValue("goal.desired")
+            .setName(BOOLEAN_PROPERTY_PREFIX + "goal.desired.name")
+            .setDescription(BOOLEAN_PROPERTY_PREFIX + "goal.desired.description")
+            .setDefaultValue(true)
+            .setRequired(true);
+
+    protected static final Value<String> CONFIGS_GOAL_QUESTION = new StringTextValue("goal.question")
+            .setName(BOOLEAN_PROPERTY_PREFIX + "goal.question.name")
+            .setDescription(BOOLEAN_PROPERTY_PREFIX + "goal.question.description")
+            .setRequired(true);
+
+
+    protected final String id;
+
+    AbstractBooleanGoalTemplateFactory(String id){
+        this.id = Objects.requireNonNull(id);
+    }
+
+    @Override
+    public final String getId() {
+        return id;
+    }
+
+    @Override
+    public final MeasurementSet getMeasurementSet() {
+        return measurements;
+    }
+
+}

--- a/studymanager-goaltemplates/src/main/java/io/redlink/more/studymanager/component/goaltemplate/BooleanGoalTemplate.java
+++ b/studymanager-goaltemplates/src/main/java/io/redlink/more/studymanager/component/goaltemplate/BooleanGoalTemplate.java
@@ -1,0 +1,23 @@
+package io.redlink.more.studymanager.component.goaltemplate;
+
+import io.redlink.more.studymanager.core.component.GoalTemplate;
+import io.redlink.more.studymanager.core.exception.ConfigurationValidationException;
+import io.redlink.more.studymanager.core.properties.GoalTemplateProperties;
+import io.redlink.more.studymanager.core.sdk.MoreGoalTemplateSDK;
+
+public class BooleanGoalTemplate<C extends GoalTemplateProperties> extends GoalTemplate<C> {
+
+
+    protected BooleanGoalTemplate(MoreGoalTemplateSDK sdk, C properties) throws ConfigurationValidationException {
+        super(sdk, properties);
+    }
+
+
+    @Override
+    public void activate() {
+    }
+
+    @Override
+    public void deactivate() {
+    }
+}

--- a/studymanager-goaltemplates/src/main/java/io/redlink/more/studymanager/component/goaltemplate/BooleanGoalTemplateFactory.java
+++ b/studymanager-goaltemplates/src/main/java/io/redlink/more/studymanager/component/goaltemplate/BooleanGoalTemplateFactory.java
@@ -1,0 +1,56 @@
+package io.redlink.more.studymanager.component.goaltemplate;
+
+import io.redlink.more.studymanager.core.exception.ConfigurationValidationException;
+import io.redlink.more.studymanager.core.factory.GoalTemplateFactory;
+import io.redlink.more.studymanager.core.properties.GoalTemplateProperties;
+import io.redlink.more.studymanager.core.properties.model.StringTextValue;
+import io.redlink.more.studymanager.core.properties.model.Value;
+import io.redlink.more.studymanager.core.sdk.MoreGoalTemplateSDK;
+
+import java.util.List;
+import java.util.Set;
+
+
+public class BooleanGoalTemplateFactory extends AbstractBooleanGoalTemplateFactory<BooleanGoalTemplate<GoalTemplateProperties>, GoalTemplateProperties>  {
+
+    public BooleanGoalTemplateFactory() {
+        super("boolean");
+    }
+
+    public List<Value> getProperties() {
+        return List.of(
+                CONFIG_SECTION_CONFIGURATION,
+                APP_TITLE,
+                APP_DESCRIPTION,
+                //GOAL_TITLE_STATE, -> title can not be modified by user!
+                //ALLOW_INSTANCES_STATE -> not multiple instances of boolean goals
+                CUSTOM_ADHERENCE_CHECKS_STATE, //allow to enable/disable custom adherence checks for multiple checks per day
+
+                CONFIG_SECTION_GOAL_CONFIGURATION,
+                CONFIGS_GOAL_QUESTION,
+                CONFIGS_GOAL_DESIRED,
+                DAYS_OF_WEEK,
+
+                ADHERENCE_CHECK_BASED_SCHEDULE_STATE,
+                SHOW_AS_TODO_ITEM_STATE,
+
+                CONFIG_SECTION_SELF_REPORT,
+                new StringTextValue("self-report-question")
+                        .setName(BOOLEAN_PROPERTY_PREFIX + "self-report-question.name")
+                        .setDescription(BOOLEAN_PROPERTY_PREFIX + "self-report-question.description")
+                        .setRequired(false)
+                        .setDefaultValue("Hast du Heute dein Ziel erreicht?")
+        );
+    }
+
+    @Override
+    public Class<GoalTemplateProperties> getPropertyClass() {
+        return GoalTemplateProperties.class;
+    }
+
+    @Override
+    public BooleanGoalTemplate<GoalTemplateProperties> create(MoreGoalTemplateSDK sdk, GoalTemplateProperties properties) throws ConfigurationValidationException {
+        return new BooleanGoalTemplate<>(sdk, properties);
+    }
+
+}

--- a/studymanager-goaltemplates/src/main/java/io/redlink/more/studymanager/component/goaltemplate/DrinkAmountOfGoalTemplateFactory.java
+++ b/studymanager-goaltemplates/src/main/java/io/redlink/more/studymanager/component/goaltemplate/DrinkAmountOfGoalTemplateFactory.java
@@ -24,6 +24,7 @@ public class DrinkAmountOfGoalTemplateFactory extends AbstractAmountOfGoalTempla
                 APP_TITLE,
                 APP_DESCRIPTION,
                 GOAL_TITLE_STATE,
+                //ALLOW_INSTANCES_STATE -> not multiple instances of amount-of goals
                 SHOW_AS_TODO_ITEM_STATE,
                 CUSTOM_SHOW_AS_TODO_ITEM_STATE,
 

--- a/studymanager-goaltemplates/src/main/java/io/redlink/more/studymanager/component/goaltemplate/DrinkAmountOfGoalTemplateFactory.java
+++ b/studymanager-goaltemplates/src/main/java/io/redlink/more/studymanager/component/goaltemplate/DrinkAmountOfGoalTemplateFactory.java
@@ -5,7 +5,6 @@ import io.redlink.more.studymanager.core.factory.GoalTemplateFactory;
 import io.redlink.more.studymanager.core.properties.GoalTemplateProperties;
 import io.redlink.more.studymanager.core.properties.model.StringTemplateValue;
 import io.redlink.more.studymanager.core.properties.model.StringTextValue;
-import io.redlink.more.studymanager.core.properties.model.StringValue;
 import io.redlink.more.studymanager.core.properties.model.Value;
 import io.redlink.more.studymanager.core.sdk.MoreGoalTemplateSDK;
 
@@ -13,20 +12,22 @@ import java.util.List;
 import java.util.Set;
 
 
-public class TrinkAmountOfGoalTemplateFactory extends AbstractAmountOfGoalTemplateFactory<AmoutOfGoalTemplate<GoalTemplateProperties>, GoalTemplateProperties>  {
+public class DrinkAmountOfGoalTemplateFactory extends AbstractAmountOfGoalTemplateFactory<AmoutOfGoalTemplate<GoalTemplateProperties>, GoalTemplateProperties>  {
 
-    public TrinkAmountOfGoalTemplateFactory() {
+    public DrinkAmountOfGoalTemplateFactory() {
         super("trink-amount-of");
     }
 
     public List<Value> getProperties() {
         return List.of(
-                AbstractAmountOfGoalTemplateFactory.CONFIG_SECTION_CONFIGURATION,
-                GoalTemplateFactory.APP_TITLE,
-                GoalTemplateFactory.APP_DESCRIPTION,
-                GoalTemplateFactory.GOAL_TITLE_STATE,
+                CONFIG_SECTION_CONFIGURATION,
+                APP_TITLE,
+                APP_DESCRIPTION,
+                GOAL_TITLE_STATE,
+                SHOW_AS_TODO_ITEM_STATE,
+                CUSTOM_SHOW_AS_TODO_ITEM_STATE,
 
-                AbstractAmountOfGoalTemplateFactory.CONFIG_SECTION_GOAL_CONFIGURATION,
+                CONFIG_SECTION_GOAL_CONFIGURATION,
                 new StringTemplateValue(
                         "goal-preview",
                         Set.of(
@@ -38,12 +39,12 @@ public class TrinkAmountOfGoalTemplateFactory extends AbstractAmountOfGoalTempla
                         .setDescription(AMOUNT_OF_PROPERTY_PREFIX + "goal-preview.description")
                         .setDefaultValue("Ich trinke mindestens <goal.amount> <goal.unit> [an <days-of-week> Tagen der Woche]")
                         .setImmutable(false),
-                AbstractAmountOfGoalTemplateFactory.CONFIGS_GOAL_AMOUNT_GROUP,
-                AbstractAmountOfGoalTemplateFactory.CONFIGS_GOAL_AMOUNT_VALUE,
-                AbstractAmountOfGoalTemplateFactory.CONFIGS_GOAL_AMOUNT_UNIT,
-                GoalTemplateFactory.DAYS_OF_WEEK,
+                CONFIGS_GOAL_AMOUNT_GROUP,
+                CONFIGS_GOAL_AMOUNT_VALUE,
+                CONFIGS_GOAL_AMOUNT_UNIT,
+                DAYS_OF_WEEK,
 
-                AbstractAmountOfGoalTemplateFactory.CONFIG_SECTION_STATUS,
+                CONFIG_SECTION_STATUS,
                 new StringTextValue("status-100-reached")
                         .setName(AMOUNT_OF_PROPERTY_PREFIX + "status-100-reached.name")
                         .setDescription(AMOUNT_OF_PROPERTY_PREFIX + "status-100-reached.description")
@@ -57,7 +58,7 @@ public class TrinkAmountOfGoalTemplateFactory extends AbstractAmountOfGoalTempla
                         .setDescription(AMOUNT_OF_PROPERTY_PREFIX + "status-not-reached.description")
                         .setDefaultValue("Du bist auf dem richtigen Weg. Jede Schluck zählt für Dein wohlbefinden."),
 
-                AbstractAmountOfGoalTemplateFactory.CONFIG_SECTION_SELF_REPORT,
+                CONFIG_SECTION_SELF_REPORT,
                 new StringTextValue("self-report-question")
                         .setName(AMOUNT_OF_PROPERTY_PREFIX + "self-report-question.name")
                         .setDescription(AMOUNT_OF_PROPERTY_PREFIX + "self-report-question.description")

--- a/studymanager-goaltemplates/src/main/java/io/redlink/more/studymanager/component/goaltemplate/EatAmountOfGoalTemplateFactory.java
+++ b/studymanager-goaltemplates/src/main/java/io/redlink/more/studymanager/component/goaltemplate/EatAmountOfGoalTemplateFactory.java
@@ -1,17 +1,12 @@
 package io.redlink.more.studymanager.component.goaltemplate;
 
-import io.redlink.more.studymanager.core.component.GoalTemplate;
 import io.redlink.more.studymanager.core.exception.ConfigurationValidationException;
-import io.redlink.more.studymanager.core.factory.ComponentFactory;
 import io.redlink.more.studymanager.core.factory.GoalTemplateFactory;
 import io.redlink.more.studymanager.core.properties.GoalTemplateProperties;
 import io.redlink.more.studymanager.core.properties.model.StringTemplateValue;
 import io.redlink.more.studymanager.core.properties.model.StringTextValue;
-import io.redlink.more.studymanager.core.properties.model.StringValue;
 import io.redlink.more.studymanager.core.properties.model.Value;
 import io.redlink.more.studymanager.core.sdk.MoreGoalTemplateSDK;
-
-import static io.redlink.more.studymanager.component.goaltemplate.AbstractAmountOfGoalTemplateFactory.*;
 
 import java.util.List;
 import java.util.Set;
@@ -25,12 +20,14 @@ public class EatAmountOfGoalTemplateFactory extends AbstractAmountOfGoalTemplate
 
     public List<Value> getProperties() {
         return List.of(
-                AbstractAmountOfGoalTemplateFactory.CONFIG_SECTION_CONFIGURATION,
-                GoalTemplateFactory.APP_TITLE,
-                GoalTemplateFactory.APP_DESCRIPTION,
-                GoalTemplateFactory.GOAL_TITLE_STATE,
+                CONFIG_SECTION_CONFIGURATION,
+                APP_TITLE,
+                APP_DESCRIPTION,
+                GOAL_TITLE_STATE,
+                SHOW_AS_TODO_ITEM_STATE,
+                CUSTOM_SHOW_AS_TODO_ITEM_STATE,
 
-                AbstractAmountOfGoalTemplateFactory.CONFIG_SECTION_GOAL_CONFIGURATION,
+                CONFIG_SECTION_GOAL_CONFIGURATION,
                 new StringTemplateValue(
                         "goal-preview",
                         Set.of(
@@ -42,12 +39,12 @@ public class EatAmountOfGoalTemplateFactory extends AbstractAmountOfGoalTemplate
                     .setDescription(AMOUNT_OF_PROPERTY_PREFIX + "goal-preview.description")
                     .setDefaultValue("Ich esse mindestens <goal.amount> Portionen <goal.unit> [an <days-of-week> Tagen der Woche]")
                     .setImmutable(false),
-                AbstractAmountOfGoalTemplateFactory.CONFIGS_GOAL_AMOUNT_GROUP,
-                AbstractAmountOfGoalTemplateFactory.CONFIGS_GOAL_AMOUNT_VALUE,
-                AbstractAmountOfGoalTemplateFactory.CONFIGS_GOAL_AMOUNT_UNIT,
-                GoalTemplateFactory.DAYS_OF_WEEK,
+                CONFIGS_GOAL_AMOUNT_GROUP,
+                CONFIGS_GOAL_AMOUNT_VALUE,
+                CONFIGS_GOAL_AMOUNT_UNIT,
+                DAYS_OF_WEEK,
 
-                AbstractAmountOfGoalTemplateFactory.CONFIG_SECTION_STATUS,
+                CONFIG_SECTION_STATUS,
                 new StringTextValue("status-100-reached")
                         .setName(AMOUNT_OF_PROPERTY_PREFIX + "status-100-reached.name")
                         .setDescription(AMOUNT_OF_PROPERTY_PREFIX + "status-100-reached.description")
@@ -61,7 +58,7 @@ public class EatAmountOfGoalTemplateFactory extends AbstractAmountOfGoalTemplate
                         .setDescription(AMOUNT_OF_PROPERTY_PREFIX + "status-not-reached.description")
                         .setDefaultValue("Du bist auf den richtigen Weg. Jede Portion zählt für Dein wohlbefinden."),
 
-                AbstractAmountOfGoalTemplateFactory.CONFIG_SECTION_SELF_REPORT,
+                CONFIG_SECTION_SELF_REPORT,
                 new StringTextValue("self-report-question")
                         .setName(AMOUNT_OF_PROPERTY_PREFIX + "self-report-question.name")
                         .setDescription(AMOUNT_OF_PROPERTY_PREFIX + "self-report-question.description")

--- a/studymanager-goaltemplates/src/main/java/io/redlink/more/studymanager/component/goaltemplate/MedicationGoalTemplate.java
+++ b/studymanager-goaltemplates/src/main/java/io/redlink/more/studymanager/component/goaltemplate/MedicationGoalTemplate.java
@@ -1,0 +1,23 @@
+package io.redlink.more.studymanager.component.goaltemplate;
+
+import io.redlink.more.studymanager.core.component.GoalTemplate;
+import io.redlink.more.studymanager.core.exception.ConfigurationValidationException;
+import io.redlink.more.studymanager.core.properties.GoalTemplateProperties;
+import io.redlink.more.studymanager.core.sdk.MoreGoalTemplateSDK;
+
+public class MedicationGoalTemplate<C extends GoalTemplateProperties> extends GoalTemplate<C> {
+
+
+    protected MedicationGoalTemplate(MoreGoalTemplateSDK sdk, C properties) throws ConfigurationValidationException {
+        super(sdk, properties);
+    }
+
+
+    @Override
+    public void activate() {
+    }
+
+    @Override
+    public void deactivate() {
+    }
+}

--- a/studymanager-goaltemplates/src/main/java/io/redlink/more/studymanager/component/goaltemplate/MedicationGoalTemplateFactory.java
+++ b/studymanager-goaltemplates/src/main/java/io/redlink/more/studymanager/component/goaltemplate/MedicationGoalTemplateFactory.java
@@ -1,0 +1,63 @@
+package io.redlink.more.studymanager.component.goaltemplate;
+
+import io.redlink.more.studymanager.core.exception.ConfigurationValidationException;
+import io.redlink.more.studymanager.core.factory.GoalTemplateFactory;
+import io.redlink.more.studymanager.core.properties.GoalTemplateProperties;
+import io.redlink.more.studymanager.core.properties.model.StringTextValue;
+import io.redlink.more.studymanager.core.properties.model.Value;
+import io.redlink.more.studymanager.core.sdk.MoreGoalTemplateSDK;
+
+import java.util.List;
+
+
+public class MedicationGoalTemplateFactory extends AbstractBooleanGoalTemplateFactory<MedicationGoalTemplate<GoalTemplateProperties>, GoalTemplateProperties>  {
+
+    public MedicationGoalTemplateFactory() {
+        super("medication");
+    }
+
+    public List<Value> getProperties() {
+        return List.of(
+                CONFIG_SECTION_CONFIGURATION,
+                APP_TITLE,
+                APP_DESCRIPTION,
+                GOAL_TITLE_STATE.copyOf()
+                        .setDefaultValue(true)
+                        .setImmutable(true),
+                ALLOW_INSTANCES_STATE.copyOf()
+                        .setDefaultValue(true)
+                        .setImmutable(true),
+                CUSTOM_ADHERENCE_CHECKS_STATE.copyOf()
+                        .setDefaultValue(true)
+                        .setImmutable(true),
+                ADHERENCE_CHECK_BASED_SCHEDULE_STATE.copyOf()
+                        .setDefaultValue(true)
+                        .setImmutable(true),
+                SHOW_AS_TODO_ITEM_STATE.copyOf()
+                        .setDefaultValue(true)
+                        .setImmutable(true),
+
+                CONFIG_SECTION_GOAL_CONFIGURATION,
+                CONFIGS_GOAL_QUESTION.copyOf()
+                        .setDefaultValue("Medikament eingenommen?"),
+
+                CONFIG_SECTION_SELF_REPORT,
+                new StringTextValue("self-report-question")
+                        .setName(BOOLEAN_PROPERTY_PREFIX + "self-report-question.name")
+                        .setDescription(BOOLEAN_PROPERTY_PREFIX + "self-report-question.description")
+                        .setRequired(false)
+                        .setDefaultValue("Hast du das Medikament eingenommen?")
+        );
+    }
+
+    @Override
+    public Class<GoalTemplateProperties> getPropertyClass() {
+        return GoalTemplateProperties.class;
+    }
+
+    @Override
+    public MedicationGoalTemplate<GoalTemplateProperties> create(MoreGoalTemplateSDK sdk, GoalTemplateProperties properties) throws ConfigurationValidationException {
+        return new MedicationGoalTemplate<>(sdk, properties);
+    }
+
+}

--- a/studymanager-goaltemplates/src/main/java/io/redlink/more/studymanager/component/goaltemplate/MedicationGoalTemplateFactory.java
+++ b/studymanager-goaltemplates/src/main/java/io/redlink/more/studymanager/component/goaltemplate/MedicationGoalTemplateFactory.java
@@ -21,18 +21,23 @@ public class MedicationGoalTemplateFactory extends AbstractBooleanGoalTemplateFa
                 CONFIG_SECTION_CONFIGURATION,
                 APP_TITLE,
                 APP_DESCRIPTION,
+                //Changing the Goal Title is allowed by participants
                 GOAL_TITLE_STATE.copyOf()
                         .setDefaultValue(true)
                         .setImmutable(true),
+                //participants can create multiple instances
                 ALLOW_INSTANCES_STATE.copyOf()
                         .setDefaultValue(true)
                         .setImmutable(true),
+                //participants are expected to assign adherence checks
                 CUSTOM_ADHERENCE_CHECKS_STATE.copyOf()
                         .setDefaultValue(true)
                         .setImmutable(true),
+                //the schedule is based on adherence checks (not the whole day)
                 ADHERENCE_CHECK_BASED_SCHEDULE_STATE.copyOf()
                         .setDefaultValue(true)
                         .setImmutable(true),
+                //medication goals are always shown in the to do list of the today tab
                 SHOW_AS_TODO_ITEM_STATE.copyOf()
                         .setDefaultValue(true)
                         .setImmutable(true),

--- a/studymanager-goaltemplates/src/main/java/io/redlink/more/studymanager/component/goaltemplate/ReduceAmountOfGoalTemplateFactory.java
+++ b/studymanager-goaltemplates/src/main/java/io/redlink/more/studymanager/component/goaltemplate/ReduceAmountOfGoalTemplateFactory.java
@@ -1,8 +1,6 @@
 package io.redlink.more.studymanager.component.goaltemplate;
 
-import io.redlink.more.studymanager.core.component.GoalTemplate;
 import io.redlink.more.studymanager.core.exception.ConfigurationValidationException;
-import io.redlink.more.studymanager.core.factory.ComponentFactory;
 import io.redlink.more.studymanager.core.factory.GoalTemplateFactory;
 import io.redlink.more.studymanager.core.properties.GoalTemplateProperties;
 import io.redlink.more.studymanager.core.properties.model.StringTemplateValue;
@@ -22,12 +20,14 @@ public class ReduceAmountOfGoalTemplateFactory extends AbstractAmountOfGoalTempl
 
     public List<Value> getProperties() {
         return List.of(
-                AbstractAmountOfGoalTemplateFactory.CONFIG_SECTION_CONFIGURATION,
-                GoalTemplateFactory.APP_TITLE,
-                GoalTemplateFactory.APP_DESCRIPTION,
-                GoalTemplateFactory.GOAL_TITLE_STATE,
+                CONFIG_SECTION_CONFIGURATION,
+                APP_TITLE,
+                APP_DESCRIPTION,
+                GOAL_TITLE_STATE,
+                SHOW_AS_TODO_ITEM_STATE,
+                CUSTOM_SHOW_AS_TODO_ITEM_STATE,
 
-                AbstractAmountOfGoalTemplateFactory.CONFIG_SECTION_GOAL_CONFIGURATION,
+                CONFIG_SECTION_GOAL_CONFIGURATION,
                 new StringTemplateValue(
                         "goal-preview",
                         Set.of(
@@ -39,17 +39,17 @@ public class ReduceAmountOfGoalTemplateFactory extends AbstractAmountOfGoalTempl
                         .setDescription(AMOUNT_OF_PROPERTY_PREFIX + "goal-preview.description")
                         .setDefaultValue("Ich <goal.activity> maximal <goal.amount> <goal.unit> [an maximal <days-of-week> Tagen in der Woche]")
                         .setImmutable(false),
-                AbstractAmountOfGoalTemplateFactory.CONFIGS_GOAL_AMOUNT_GROUP,
+                CONFIGS_GOAL_AMOUNT_GROUP,
                 new StringValue("goal.activity")
                         .setName(GOAL_TEMPLATE_PROPERTY_PREFIX + "reduceAmountOf.goal.activity.name")
                         .setDescription(GOAL_TEMPLATE_PROPERTY_PREFIX + "reduceAmountOf.goal.activity.description")
                         .setDefaultValue("konsumiere")
                         .setRequired(true),
-                AbstractAmountOfGoalTemplateFactory.CONFIGS_GOAL_AMOUNT_VALUE,
-                AbstractAmountOfGoalTemplateFactory.CONFIGS_GOAL_AMOUNT_UNIT,
-                GoalTemplateFactory.DAYS_OF_WEEK,
+                CONFIGS_GOAL_AMOUNT_VALUE,
+                CONFIGS_GOAL_AMOUNT_UNIT,
+                DAYS_OF_WEEK,
 
-                AbstractAmountOfGoalTemplateFactory.CONFIG_SECTION_STATUS,
+                CONFIG_SECTION_STATUS,
                 new StringTextValue("status-day-not-consumed")
                         .setName(AMOUNT_OF_PROPERTY_PREFIX + "status-day-not-consumed.name")
                         .setDescription(AMOUNT_OF_PROPERTY_PREFIX + "status-day-not-consumed.description")
@@ -63,7 +63,7 @@ public class ReduceAmountOfGoalTemplateFactory extends AbstractAmountOfGoalTempl
                         .setDescription(AMOUNT_OF_PROPERTY_PREFIX + "status-day-over-limit.description")
                         .setDefaultValue("Du hast heute mehr konsumiert als ausgemacht. Bleib dran. Morgen geht es wieder besser."),
 
-                AbstractAmountOfGoalTemplateFactory.CONFIG_SECTION_SELF_REPORT,
+                CONFIG_SECTION_SELF_REPORT,
                 new StringTextValue("self-report-question")
                         .setName(AMOUNT_OF_PROPERTY_PREFIX + "self-report-question.name")
                         .setDescription(AMOUNT_OF_PROPERTY_PREFIX + "self-report-question.description")

--- a/studymanager-goaltemplates/src/main/java/io/redlink/more/studymanager/core/factory/GoalTemplateFactory.java
+++ b/studymanager-goaltemplates/src/main/java/io/redlink/more/studymanager/core/factory/GoalTemplateFactory.java
@@ -136,4 +136,30 @@ public abstract class GoalTemplateFactory<C extends GoalTemplate<P>, P extends G
             .setDescription(GLOBAL_PROPERTY_PREFIX + "customAdherenceChecksState.description")
             .setDefaultValue(false);
 
+    /**
+     * If enabled the schedule for a goal is calculated based on the actuve adherence checks. If disabled the goal is
+     * active the whole day.
+     */
+    public static final Value<Boolean> ADHERENCE_CHECK_BASED_SCHEDULE_STATE = new BooleanValue("adherence-check-schedule-state")
+            .setName(GLOBAL_PROPERTY_PREFIX + "adherenceChecksScheduleState.name")
+            .setDescription(GLOBAL_PROPERTY_PREFIX + "adherenceChecksScheduleState.description")
+            .setDefaultValue(false);
+
+    /**
+     * If enabled the activity of the goal is shown as a to do itme in the praecura app. This allows interacting with
+     * the goal step directly via the today view
+     */
+    public static final Value<Boolean> SHOW_AS_TODO_ITEM_STATE = new BooleanValue("show-as-todo-item-state")
+            .setName(GLOBAL_PROPERTY_PREFIX + "showAsTodoItemState.name")
+            .setDescription(GLOBAL_PROPERTY_PREFIX + "showAsTodoItemState.description")
+            .setDefaultValue(false);
+    /**
+     * If enabled the participant can activate/disactivate if the goal is included in the to do item list. The
+     * <code>show-as-todo-item-state</code> is used as a default
+     */
+    public static final Value<Boolean> CUSTOM_SHOW_AS_TODO_ITEM_STATE = new BooleanValue("custom-show-as-todo-item-state")
+            .setName(GLOBAL_PROPERTY_PREFIX + "customShowAsTodoItemState.name")
+            .setDescription(GLOBAL_PROPERTY_PREFIX + "customShowAsTodoItemState.description")
+            .setDefaultValue(false);
+
 }


### PR DESCRIPTION
* Added functionality to the Value system to create a deep copy (clone) of a value. This allows to take a constant for an value and modify its properties for a specific template (e.g. define the value of a state for a specific goal template - such as that changing the title is allowed for all medication goal templates).
* Added GoalTemplates for Boolean (YES/NO) type of goals and Medication goals. 
* Also adapted existing templates for newly added features